### PR TITLE
fix: use exec() for daemon logs --follow to handle Ctrl+C

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod theme;
 mod ui;
 
 use std::io;
+use std::os::unix::process::CommandExt;
 use std::time::Duration;
 
 use app::App;
@@ -1010,10 +1011,13 @@ fn run_daemon_command(command: DaemonCommands) -> Result<()> {
             }
 
             if follow {
-                std::process::Command::new("tail")
+                // Use exec() to replace this process with tail, so Ctrl+C works properly
+                let err = std::process::Command::new("tail")
                     .args(["-f", "-n", &lines.to_string()])
                     .arg(&path)
-                    .status()?;
+                    .exec();
+                // exec() only returns if it fails
+                return Err(err.into());
             } else {
                 std::process::Command::new("tail")
                     .args(["-n", &lines.to_string()])


### PR DESCRIPTION
## Summary

- Fix Ctrl+C not terminating `jolt daemon logs --follow`
- Replace `status()` with Unix `exec()` so the jolt process is replaced by `tail`, allowing signals to reach it directly

## Changes

- `src/main.rs` - Use `CommandExt::exec()` instead of `status()` for follow mode, which replaces the process rather than spawning a child

Fixes #18