### PR TITLE
refactor: remove dead code and unnecessary dead_code annotations

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -40,18 +40,6 @@ impl LogLevel {
             _ => LogLevel::Info,
         }
     }
-
-    #[allow(dead_code)]
-    pub fn label(&self) -> &'static str {
-        match self {
-            LogLevel::Off => "off",
-            LogLevel::Error => "error",
-            LogLevel::Warn => "warn",
-            LogLevel::Info => "info",
-            LogLevel::Debug => "debug",
-            LogLevel::Trace => "trace",
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]

--- a/cli/src/daemon/client.rs
+++ b/cli/src/daemon/client.rs
@@ -20,7 +20,6 @@ pub enum ClientError {
     #[error("Daemon error: {0}")]
     Daemon(String),
 
-    #[allow(dead_code)]
     #[error("Subscription rejected: {0}")]
     SubscriptionRejected(String),
 }
@@ -171,16 +170,6 @@ impl DaemonClient {
         }
     }
 
-    #[allow(dead_code)]
-    pub fn get_current_data(&mut self) -> Result<DataSnapshot> {
-        match self.send_request(DaemonRequest::GetCurrentData)? {
-            DaemonResponse::CurrentData(snapshot) => Ok(snapshot),
-            DaemonResponse::Error(e) => Err(ClientError::Daemon(e)),
-            _ => Err(ClientError::Protocol("Unexpected response".into())),
-        }
-    }
-
-    #[allow(dead_code)]
     pub fn kill_process(&mut self, pid: u32, signal: KillSignal) -> Result<KillProcessResult> {
         match self.send_request(DaemonRequest::KillProcess { pid, signal })? {
             DaemonResponse::KillResult(result) => Ok(result),
@@ -189,7 +178,6 @@ impl DaemonClient {
         }
     }
 
-    #[allow(dead_code)]
     pub fn subscribe(&mut self) -> Result<()> {
         match self.send_request(DaemonRequest::Subscribe)? {
             DaemonResponse::Subscribed => Ok(()),
@@ -209,7 +197,6 @@ impl DaemonClient {
         }
     }
 
-    #[allow(dead_code)]
     pub fn unsubscribe(&mut self) -> Result<()> {
         match self.send_request(DaemonRequest::Unsubscribe)? {
             DaemonResponse::Unsubscribed => Ok(()),
@@ -245,7 +232,6 @@ impl DaemonClient {
         }
     }
 
-    #[allow(dead_code)]
     pub fn read_update(&mut self) -> Result<Option<DataSnapshot>> {
         match self.read_line_nonblocking()? {
             None => Ok(None),
@@ -282,7 +268,6 @@ impl DaemonClient {
         }
     }
 
-    #[allow(dead_code)]
     pub fn set_nonblocking(&mut self, nonblocking: bool) -> Result<()> {
         self.stream.set_nonblocking(nonblocking)?;
         if nonblocking {
@@ -290,197 +275,5 @@ impl DaemonClient {
             self.stream.set_write_timeout(None)?;
         }
         Ok(())
-    }
-}
-
-#[allow(dead_code)]
-pub mod async_client {
-    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-    use tokio::net::UnixStream;
-
-    use crate::daemon::protocol::{
-        DaemonRequest, DaemonResponse, DaemonStatus, DataSnapshot, KillProcessResult, KillSignal,
-    };
-    use crate::daemon::socket_path;
-    use crate::data::{DailyStat, DailyTopProcess, HourlyStat, Sample};
-
-    #[derive(Debug, thiserror::Error)]
-    pub enum AsyncClientError {
-        #[error("Connection failed: {0}")]
-        Connection(#[from] std::io::Error),
-
-        #[error("Protocol error: {0}")]
-        Protocol(String),
-
-        #[error("Daemon error: {0}")]
-        Daemon(String),
-
-        #[error("Subscription rejected: {0}")]
-        SubscriptionRejected(String),
-    }
-
-    pub type Result<T> = std::result::Result<T, AsyncClientError>;
-
-    pub struct AsyncDaemonClient {
-        reader: BufReader<tokio::net::unix::OwnedReadHalf>,
-        writer: tokio::net::unix::OwnedWriteHalf,
-    }
-
-    impl AsyncDaemonClient {
-        pub async fn connect() -> Result<Self> {
-            let path = socket_path();
-            let stream = UnixStream::connect(&path).await?;
-            let (reader, writer) = stream.into_split();
-            Ok(Self {
-                reader: BufReader::new(reader),
-                writer,
-            })
-        }
-
-        async fn send_request(&mut self, request: DaemonRequest) -> Result<DaemonResponse> {
-            let json = request
-                .to_json()
-                .map_err(|e| AsyncClientError::Protocol(e.to_string()))?;
-
-            self.writer
-                .write_all(format!("{}\n", json).as_bytes())
-                .await?;
-
-            let mut line = String::new();
-            self.reader.read_line(&mut line).await?;
-
-            DaemonResponse::from_json(&line).map_err(|e| AsyncClientError::Protocol(e.to_string()))
-        }
-
-        pub async fn get_status(&mut self) -> Result<DaemonStatus> {
-            match self.send_request(DaemonRequest::GetStatus).await? {
-                DaemonResponse::Status(status) => Ok(status),
-                DaemonResponse::Error(e) => Err(AsyncClientError::Daemon(e)),
-                _ => Err(AsyncClientError::Protocol("Unexpected response".into())),
-            }
-        }
-
-        pub async fn get_hourly_stats(&mut self, from: i64, to: i64) -> Result<Vec<HourlyStat>> {
-            match self
-                .send_request(DaemonRequest::GetHourlyStats { from, to })
-                .await?
-            {
-                DaemonResponse::HourlyStats(stats) => Ok(stats),
-                DaemonResponse::Error(e) => Err(AsyncClientError::Daemon(e)),
-                _ => Err(AsyncClientError::Protocol("Unexpected response".into())),
-            }
-        }
-
-        pub async fn get_daily_stats(&mut self, from: &str, to: &str) -> Result<Vec<DailyStat>> {
-            match self
-                .send_request(DaemonRequest::GetDailyStats {
-                    from: from.to_string(),
-                    to: to.to_string(),
-                })
-                .await?
-            {
-                DaemonResponse::DailyStats(stats) => Ok(stats),
-                DaemonResponse::Error(e) => Err(AsyncClientError::Daemon(e)),
-                _ => Err(AsyncClientError::Protocol("Unexpected response".into())),
-            }
-        }
-
-        pub async fn get_top_processes_range(
-            &mut self,
-            from: &str,
-            to: &str,
-            limit: usize,
-        ) -> Result<Vec<DailyTopProcess>> {
-            match self
-                .send_request(DaemonRequest::GetTopProcessesRange {
-                    from: from.to_string(),
-                    to: to.to_string(),
-                    limit,
-                })
-                .await?
-            {
-                DaemonResponse::TopProcesses(processes) => Ok(processes),
-                DaemonResponse::Error(e) => Err(AsyncClientError::Daemon(e)),
-                _ => Err(AsyncClientError::Protocol("Unexpected response".into())),
-            }
-        }
-
-        pub async fn shutdown(&mut self) -> Result<()> {
-            match self.send_request(DaemonRequest::Shutdown).await? {
-                DaemonResponse::Ok => Ok(()),
-                DaemonResponse::Error(e) => Err(AsyncClientError::Daemon(e)),
-                _ => Err(AsyncClientError::Protocol("Unexpected response".into())),
-            }
-        }
-
-        pub async fn get_recent_samples(&mut self, window_secs: u64) -> Result<Vec<Sample>> {
-            match self
-                .send_request(DaemonRequest::GetRecentSamples { window_secs })
-                .await?
-            {
-                DaemonResponse::RecentSamples(samples) => Ok(samples),
-                DaemonResponse::Error(e) => Err(AsyncClientError::Daemon(e)),
-                _ => Err(AsyncClientError::Protocol("Unexpected response".into())),
-            }
-        }
-
-        pub async fn get_current_data(&mut self) -> Result<DataSnapshot> {
-            match self.send_request(DaemonRequest::GetCurrentData).await? {
-                DaemonResponse::CurrentData(snapshot) => Ok(snapshot),
-                DaemonResponse::Error(e) => Err(AsyncClientError::Daemon(e)),
-                _ => Err(AsyncClientError::Protocol("Unexpected response".into())),
-            }
-        }
-
-        pub async fn kill_process(
-            &mut self,
-            pid: u32,
-            signal: KillSignal,
-        ) -> Result<KillProcessResult> {
-            match self
-                .send_request(DaemonRequest::KillProcess { pid, signal })
-                .await?
-            {
-                DaemonResponse::KillResult(result) => Ok(result),
-                DaemonResponse::Error(e) => Err(AsyncClientError::Daemon(e)),
-                _ => Err(AsyncClientError::Protocol("Unexpected response".into())),
-            }
-        }
-
-        pub async fn subscribe(&mut self) -> Result<()> {
-            match self.send_request(DaemonRequest::Subscribe).await? {
-                DaemonResponse::Subscribed => Ok(()),
-                DaemonResponse::SubscriptionRejected { reason } => {
-                    Err(AsyncClientError::SubscriptionRejected(reason))
-                }
-                DaemonResponse::Error(e) => Err(AsyncClientError::Daemon(e)),
-                _ => Err(AsyncClientError::Protocol("Unexpected response".into())),
-            }
-        }
-
-        pub async fn unsubscribe(&mut self) -> Result<()> {
-            match self.send_request(DaemonRequest::Unsubscribe).await? {
-                DaemonResponse::Unsubscribed => Ok(()),
-                DaemonResponse::Error(e) => Err(AsyncClientError::Daemon(e)),
-                _ => Err(AsyncClientError::Protocol("Unexpected response".into())),
-            }
-        }
-
-        pub async fn read_update(&mut self) -> Result<Option<DataSnapshot>> {
-            let mut line = String::new();
-            match self.reader.read_line(&mut line).await {
-                Ok(0) => Ok(None),
-                Ok(_) => {
-                    let response = DaemonResponse::from_json(&line)
-                        .map_err(|e| AsyncClientError::Protocol(e.to_string()))?;
-                    match response {
-                        DaemonResponse::DataUpdate(snapshot) => Ok(Some(snapshot)),
-                        DaemonResponse::Error(e) => Err(AsyncClientError::Daemon(e)),
-                        _ => Ok(None),
-                    }
-                }
-                Err(e) => Err(AsyncClientError::Connection(e)),
-            }
-        }
     }
 }

--- a/cli/src/daemon/mod.rs
+++ b/cli/src/daemon/mod.rs
@@ -2,8 +2,6 @@ mod client;
 mod protocol;
 mod server;
 
-#[allow(unused_imports)]
-pub use client::async_client::{AsyncClientError, AsyncDaemonClient};
 pub use client::DaemonClient;
 #[allow(unused_imports)]
 pub use protocol::{

--- a/cli/src/daemon/protocol.rs
+++ b/cli/src/daemon/protocol.rs
@@ -2,7 +2,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::data::{ChargeSession, DailyCycle, DailyStat, DailyTopProcess, HourlyStat, Sample};
 
-#[allow(dead_code)]
 pub const MAX_SUBSCRIBERS: usize = 10;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]

--- a/cli/src/data/display.rs
+++ b/cli/src/data/display.rs
@@ -65,11 +65,6 @@ impl DisplayData {
     pub fn brightness_percent(&self) -> f32 {
         self.brightness_percent
     }
-
-    #[allow(dead_code)]
-    pub fn max_nits(&self) -> Option<u32> {
-        self.max_nits
-    }
 }
 
 fn extract_number(line: &str) -> Option<i64> {

--- a/cli/src/data/session_tracker.rs
+++ b/cli/src/data/session_tracker.rs
@@ -234,11 +234,6 @@ impl SessionTracker {
     pub fn reset_time_at_high_soc(&mut self) {
         self.time_at_high_soc_secs = 0;
     }
-
-    #[allow(dead_code)]
-    pub fn get_time_at_high_soc_secs(&self) -> i64 {
-        self.time_at_high_soc_secs
-    }
 }
 
 impl Default for SessionTracker {


### PR DESCRIPTION
## Summary

- Removed 232 lines of dead code that was marked with `#[allow(dead_code)]`
- Removed unnecessary `#[allow(dead_code)]` annotations from items that are actually used

## Dead Code Removed

| Item | Lines | Reason |
|------|-------|--------|
| `async_client` module | ~190 | Never used - sync client with non-blocking socket is sufficient for the TUI's tick-based polling |
| `LogLevel::label()` | 12 | Unused method (not the same as `AppearanceMode::label()`) |
| `DisplayData::max_nits()` | 5 | Unused getter |
| `SessionTracker::get_time_at_high_soc_secs()` | 5 | Unused getter |
| `DaemonClient::get_current_data()` | 9 | Only referenced in tests, not actual code |

### Why `async_client` was removed

The async client module was added in #28 as speculative "future-proofing" but was never used. The TUI uses a sync client configured with `set_nonblocking(true)` which:
- Returns immediately if no data available (`WouldBlock` → `Ok(None)`)
- Fits the existing tick-based polling loop
- Avoids needing a tokio runtime in the TUI (tokio is still used by the daemon server)

## Unnecessary Annotations Removed

These items had `#[allow(dead_code)]` but ARE actually used:

| Item | Used By |
|------|---------|
| `ClientError::SubscriptionRejected` | `subscribe()` error handling |
| `DaemonClient::kill_process()` | `app.rs:1329` |
| `DaemonClient::subscribe()` | `app.rs:327` |
| `DaemonClient::unsubscribe()` | `app.rs:1346` |
| `DaemonClient::read_update()` | `app.rs:414` |
| `DaemonClient::set_nonblocking()` | `app.rs:327` |
| `MAX_SUBSCRIBERS` | `daemon/server.rs` |

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test` ✅ (48 tests pass)