### PR TITLE
feat(ui): add battery details popup and enhanced graph aesthetics

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -80,6 +80,7 @@ pub enum Action {
     SettingsToggleValue,
     SettingsIncrement,
     SettingsDecrement,
+    ToggleBatteryDetails,
     None,
 }
 
@@ -166,6 +167,7 @@ pub enum AppView {
     ThemeImporter,
     History,
     Settings,
+    BatteryDetails,
 }
 
 pub struct App {
@@ -397,6 +399,7 @@ impl App {
             self.history.record(
                 self.battery.charge_percent(),
                 self.power.total_power_watts(),
+                self.battery.temperature_c(),
             );
 
             if self.tick_count.is_multiple_of(FORECAST_REFRESH_TICKS) {
@@ -870,6 +873,12 @@ impl App {
                         self.open_theme_picker_from_config();
                     }
                 }
+            }
+            Action::ToggleBatteryDetails => {
+                self.view = match self.view {
+                    AppView::BatteryDetails => AppView::Main,
+                    _ => AppView::BatteryDetails,
+                };
             }
             Action::None => {}
         }

--- a/cli/src/data/battery.rs
+++ b/cli/src/data/battery.rs
@@ -5,7 +5,7 @@ use jolt_platform::BatteryProvider;
 
 use crate::daemon::{BatterySnapshot, BatteryState as ProtocolBatteryState};
 
-pub use jolt_platform::ChargeState;
+pub use jolt_platform::{BatteryTechnology, ChargeState};
 
 #[cfg(target_os = "macos")]
 type PlatformBattery = jolt_platform::macos::MacOSBattery;
@@ -156,6 +156,30 @@ impl BatteryData {
 
     pub fn discharge_watts(&self) -> Option<f32> {
         self.provider.info().discharge_watts()
+    }
+
+    pub fn vendor(&self) -> Option<&str> {
+        self.provider.info().vendor.as_deref()
+    }
+
+    pub fn model(&self) -> Option<&str> {
+        self.provider.info().model.as_deref()
+    }
+
+    pub fn serial_number(&self) -> Option<&str> {
+        self.provider.info().serial_number.as_deref()
+    }
+
+    pub fn technology(&self) -> BatteryTechnology {
+        self.provider.info().technology
+    }
+
+    pub fn energy_wh(&self) -> f32 {
+        self.provider.info().energy_wh
+    }
+
+    pub fn energy_rate_watts(&self) -> f32 {
+        self.provider.info().energy_rate_watts
     }
 
     pub fn update_from_snapshot(&mut self, snapshot: &BatterySnapshot) {

--- a/cli/src/data/forecast.rs
+++ b/cli/src/data/forecast.rs
@@ -340,14 +340,17 @@ mod tests {
             DataPoint {
                 battery_percent: 80.0,
                 power_watts: 10.0,
+                temperature_c: None,
             },
             DataPoint {
                 battery_percent: 79.0,
                 power_watts: 12.0,
+                temperature_c: None,
             },
             DataPoint {
                 battery_percent: 78.0,
                 power_watts: 11.0,
+                temperature_c: None,
             },
         ];
 
@@ -372,6 +375,7 @@ mod tests {
         let points = vec![DataPoint {
             battery_percent: 80.0,
             power_watts: 10.0,
+            temperature_c: None,
         }];
 
         let result = forecast.calculate_from_session_data(&points, 50.0, 100.0);

--- a/cli/src/data/history.rs
+++ b/cli/src/data/history.rs
@@ -8,7 +8,6 @@ pub enum HistoryMetric {
     Battery,
     Split,
     Merged,
-    HourlyBars,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -79,8 +78,7 @@ impl HistoryData {
             HistoryMetric::Power => HistoryMetric::Battery,
             HistoryMetric::Battery => HistoryMetric::Merged,
             HistoryMetric::Merged => HistoryMetric::Split,
-            HistoryMetric::Split => HistoryMetric::HourlyBars,
-            HistoryMetric::HourlyBars => HistoryMetric::Power,
+            HistoryMetric::Split => HistoryMetric::Power,
         };
     }
 
@@ -90,17 +88,15 @@ impl HistoryData {
             HistoryMetric::Power => "Power (W)",
             HistoryMetric::Split => "Split View",
             HistoryMetric::Merged => "Combined",
-            HistoryMetric::HourlyBars => "Hourly Power",
         }
     }
 
     pub fn current_values(&self) -> Vec<(f64, f64)> {
         let values: Vec<f32> = match self.current_metric {
             HistoryMetric::Battery => self.points.iter().map(|p| p.battery_percent).collect(),
-            HistoryMetric::Power
-            | HistoryMetric::Split
-            | HistoryMetric::Merged
-            | HistoryMetric::HourlyBars => self.points.iter().map(|p| p.power_watts).collect(),
+            HistoryMetric::Power | HistoryMetric::Split | HistoryMetric::Merged => {
+                self.points.iter().map(|p| p.power_watts).collect()
+            }
         };
 
         values
@@ -129,10 +125,7 @@ impl HistoryData {
     pub fn value_range(&self) -> (f64, f64) {
         match self.current_metric {
             HistoryMetric::Battery => (0.0, 100.0),
-            HistoryMetric::Power
-            | HistoryMetric::Split
-            | HistoryMetric::Merged
-            | HistoryMetric::HourlyBars => {
+            HistoryMetric::Power | HistoryMetric::Split | HistoryMetric::Merged => {
                 let max = self
                     .points
                     .iter()

--- a/cli/src/data/history.rs
+++ b/cli/src/data/history.rs
@@ -8,6 +8,7 @@ pub enum HistoryMetric {
     Battery,
     Split,
     Merged,
+    HourlyBars,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -78,7 +79,8 @@ impl HistoryData {
             HistoryMetric::Power => HistoryMetric::Battery,
             HistoryMetric::Battery => HistoryMetric::Merged,
             HistoryMetric::Merged => HistoryMetric::Split,
-            HistoryMetric::Split => HistoryMetric::Power,
+            HistoryMetric::Split => HistoryMetric::HourlyBars,
+            HistoryMetric::HourlyBars => HistoryMetric::Power,
         };
     }
 
@@ -88,15 +90,17 @@ impl HistoryData {
             HistoryMetric::Power => "Power (W)",
             HistoryMetric::Split => "Split View",
             HistoryMetric::Merged => "Combined",
+            HistoryMetric::HourlyBars => "Hourly Power",
         }
     }
 
     pub fn current_values(&self) -> Vec<(f64, f64)> {
         let values: Vec<f32> = match self.current_metric {
             HistoryMetric::Battery => self.points.iter().map(|p| p.battery_percent).collect(),
-            HistoryMetric::Power | HistoryMetric::Split | HistoryMetric::Merged => {
-                self.points.iter().map(|p| p.power_watts).collect()
-            }
+            HistoryMetric::Power
+            | HistoryMetric::Split
+            | HistoryMetric::Merged
+            | HistoryMetric::HourlyBars => self.points.iter().map(|p| p.power_watts).collect(),
         };
 
         values
@@ -125,7 +129,10 @@ impl HistoryData {
     pub fn value_range(&self) -> (f64, f64) {
         match self.current_metric {
             HistoryMetric::Battery => (0.0, 100.0),
-            HistoryMetric::Power | HistoryMetric::Split | HistoryMetric::Merged => {
+            HistoryMetric::Power
+            | HistoryMetric::Split
+            | HistoryMetric::Merged
+            | HistoryMetric::HourlyBars => {
                 let max = self
                     .points
                     .iter()

--- a/cli/src/input.rs
+++ b/cli/src/input.rs
@@ -18,6 +18,7 @@ pub mod keys {
     pub const PERIOD_NEXT: &str = "\u{2192}";
     pub const ESC: &str = "Esc";
     pub const SETTINGS: &str = "s";
+    pub const BATTERY_DETAILS: &str = "b";
 }
 
 pub fn handle_key(app: &App, key: KeyEvent) -> Action {
@@ -36,6 +37,7 @@ pub fn handle_key(app: &App, key: KeyEvent) -> Action {
         }
         AppView::History => handle_history_keys(key),
         AppView::Settings => handle_settings_keys(key),
+        AppView::BatteryDetails => handle_battery_details_keys(key),
     }
 }
 
@@ -70,6 +72,7 @@ fn handle_main_keys(key: KeyEvent, selection_mode: bool) -> Action {
         KeyCode::Char('-') => Action::DecreaseRefreshRate,
         KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => Action::Quit,
         KeyCode::Char('h') => Action::ToggleHistory,
+        KeyCode::Char('b') => Action::ToggleBatteryDetails,
         _ => Action::None,
     }
 }
@@ -163,6 +166,13 @@ fn handle_settings_keys(key: KeyEvent) -> Action {
     }
 }
 
+fn handle_battery_details_keys(key: KeyEvent) -> Action {
+    match key.code {
+        KeyCode::Esc | KeyCode::Char('b') | KeyCode::Char('q') => Action::ToggleBatteryDetails,
+        _ => Action::None,
+    }
+}
+
 pub struct KeyBinding {
     pub key: &'static str,
     pub description: &'static str,
@@ -240,6 +250,10 @@ pub const KEY_BINDINGS: &[KeyBinding] = &[
     KeyBinding {
         key: keys::HISTORY,
         description: "View history",
+    },
+    KeyBinding {
+        key: keys::BATTERY_DETAILS,
+        description: "Battery details",
     },
     KeyBinding {
         key: keys::QUIT,

--- a/cli/src/ui/battery.rs
+++ b/cli/src/ui/battery.rs
@@ -318,7 +318,7 @@ fn render_battery_info_card(frame: &mut Frame, area: Rect, app: &App, theme: &Th
 
         let row1 = Line::from(row1_spans);
 
-        let row2 = Line::from(vec![
+        let mut row2_spans = vec![
             Span::styled("Health: ", Style::default().fg(theme.muted)),
             Span::styled(
                 format!("{:.0}%", app.battery.health_percent()),
@@ -335,7 +335,31 @@ fn render_battery_info_card(frame: &mut Frame, area: Rect, app: &App, theme: &Th
             Span::styled("  │  ", Style::default().fg(theme.border)),
             Span::styled("Cycles: ", Style::default().fg(theme.muted)),
             Span::styled(&cycles_text, Style::default().fg(theme.fg)),
-        ]);
+        ];
+
+        if let Some(temp) = app.battery.temperature_c() {
+            row2_spans.push(Span::styled("  │  ", Style::default().fg(theme.border)));
+            row2_spans.push(Span::styled(
+                format!("{:.1}°C", temp),
+                Style::default().fg(theme.warning),
+            ));
+        }
+
+        row2_spans.push(Span::styled("  │  ", Style::default().fg(theme.border)));
+        row2_spans.push(Span::styled(
+            format!("{:.1}Wh", app.battery.energy_wh()),
+            Style::default().fg(theme.fg),
+        ));
+
+        if let (Some(min), Some(max)) = (app.battery.daily_min_soc(), app.battery.daily_max_soc()) {
+            row2_spans.push(Span::styled("  │  ", Style::default().fg(theme.border)));
+            row2_spans.push(Span::styled(
+                format!("{:.0}-{:.0}%", min, max),
+                Style::default().fg(theme.muted),
+            ));
+        }
+
+        let row2 = Line::from(row2_spans);
 
         frame.render_widget(Paragraph::new(row1).centered(), rows[0]);
         frame.render_widget(Paragraph::new(row2).centered(), rows[2]);

--- a/cli/src/ui/battery_details.rs
+++ b/cli/src/ui/battery_details.rs
@@ -1,0 +1,288 @@
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    symbols::Marker,
+    text::{Line, Span},
+    widgets::{Axis, Block, Borders, Chart, Clear, Dataset, GraphType, Paragraph},
+    Frame,
+};
+
+use crate::app::App;
+use crate::theme::ThemeColors;
+
+fn centered_rect(area: Rect, width: u16, height: u16) -> Rect {
+    let width = width.min(area.width.saturating_sub(4));
+    let height = height.min(area.height.saturating_sub(2));
+    let x = area.x + (area.width.saturating_sub(width)) / 2;
+    let y = area.y + (area.height.saturating_sub(height)) / 2;
+    Rect::new(x, y, width, height)
+}
+
+fn color_for_percent(percent: f32, high: f32, low: f32, theme: &ThemeColors) -> Color {
+    if percent > high {
+        theme.success
+    } else if percent > low {
+        theme.warning
+    } else {
+        theme.danger
+    }
+}
+
+pub fn render(frame: &mut Frame, app: &App, theme: &ThemeColors) {
+    let popup_width = 70;
+    let popup_height = 28;
+    let area = centered_rect(frame.area(), popup_width, popup_height);
+
+    frame.render_widget(Clear, area);
+
+    let block = Block::default()
+        .title(" Battery Details ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.accent))
+        .style(Style::default().bg(theme.dialog_bg));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let has_temp_data = app.history.has_temperature_data();
+    let chart_height = if has_temp_data { 8 } else { 0 };
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(1)
+        .constraints([
+            Constraint::Length(4),
+            Constraint::Length(3),
+            Constraint::Length(3),
+            Constraint::Length(3),
+            Constraint::Length(2),
+            Constraint::Length(chart_height),
+            Constraint::Min(1),
+        ])
+        .split(inner);
+
+    render_device_info(frame, chunks[0], app, theme);
+    render_charge_info(frame, chunks[1], app, theme);
+    render_health_info(frame, chunks[2], app, theme);
+    render_electrical_info(frame, chunks[3], app, theme);
+    render_daily_soc(frame, chunks[4], app, theme);
+
+    if has_temp_data {
+        render_temperature_chart(frame, chunks[5], app, theme);
+    }
+
+    render_footer(frame, chunks[6], theme);
+}
+
+fn render_device_info(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeColors) {
+    let vendor = app.battery.vendor().unwrap_or("Unknown");
+    let model = app.battery.model().unwrap_or("Unknown");
+    let serial = app.battery.serial_number().unwrap_or("N/A");
+    let technology = app.battery.technology().label();
+
+    let lines = vec![
+        Line::from(vec![
+            Span::styled("Vendor:     ", Style::default().fg(theme.muted)),
+            Span::styled(vendor, Style::default().fg(theme.fg)),
+            Span::styled("          Model:  ", Style::default().fg(theme.muted)),
+            Span::styled(model, Style::default().fg(theme.fg)),
+        ]),
+        Line::from(vec![
+            Span::styled("Serial:     ", Style::default().fg(theme.muted)),
+            Span::styled(serial, Style::default().fg(theme.fg)),
+        ]),
+        Line::from(vec![
+            Span::styled("Technology: ", Style::default().fg(theme.muted)),
+            Span::styled(technology, Style::default().fg(theme.fg)),
+        ]),
+    ];
+
+    let paragraph = Paragraph::new(lines);
+    frame.render_widget(paragraph, area);
+}
+
+fn render_charge_info(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeColors) {
+    let percent = app.battery.charge_percent();
+    let energy = app.battery.energy_wh();
+    let max_capacity = app.battery.max_capacity_wh();
+    let state = app.battery.state_label();
+
+    let percent_color = color_for_percent(percent, 50.0, 20.0, theme);
+
+    let gauge_width = 20;
+    let filled = ((percent / 100.0) * gauge_width as f32) as usize;
+    let empty = gauge_width - filled;
+    let gauge_str = format!("{}{}", "█".repeat(filled), "░".repeat(empty));
+
+    let lines = vec![
+        Line::from(vec![
+            Span::styled("Charge:     ", Style::default().fg(theme.muted)),
+            Span::styled(
+                format!("{:.1}%", percent),
+                Style::default()
+                    .fg(percent_color)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("  ", Style::default()),
+            Span::styled(&gauge_str, Style::default().fg(percent_color)),
+            Span::styled(
+                format!("  ({:.1} Wh)", energy),
+                Style::default().fg(theme.muted),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("Status:     ", Style::default().fg(theme.muted)),
+            Span::styled(state, Style::default().fg(theme.fg)),
+            Span::styled(
+                format!("          Capacity: {:.1} Wh", max_capacity),
+                Style::default().fg(theme.muted),
+            ),
+        ]),
+    ];
+
+    let paragraph = Paragraph::new(lines);
+    frame.render_widget(paragraph, area);
+}
+
+fn render_health_info(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeColors) {
+    let health = app.battery.health_percent();
+    let cycles = app.battery.cycle_count();
+    let design_capacity = app.battery.design_capacity_wh();
+    let max_capacity = app.battery.max_capacity_wh();
+
+    let health_color = color_for_percent(health, 80.0, 50.0, theme);
+
+    let cycles_str = cycles.map_or("N/A".to_string(), |c| c.to_string());
+
+    let lines = vec![
+        Line::from(vec![
+            Span::styled("Health:     ", Style::default().fg(theme.muted)),
+            Span::styled(
+                format!("{:.1}%", health),
+                Style::default()
+                    .fg(health_color)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!("  ({:.1} / {:.1} Wh)", max_capacity, design_capacity),
+                Style::default().fg(theme.muted),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("Cycles:     ", Style::default().fg(theme.muted)),
+            Span::styled(&cycles_str, Style::default().fg(theme.fg)),
+        ]),
+    ];
+
+    let paragraph = Paragraph::new(lines);
+    frame.render_widget(paragraph, area);
+}
+
+fn render_electrical_info(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeColors) {
+    let temp = app.battery.temperature_c();
+    let voltage = app.battery.voltage_mv();
+    let amperage = app.battery.amperage_ma();
+    let energy_rate = app.battery.energy_rate_watts();
+
+    let temp_str = temp.map_or("N/A".to_string(), |t| format!("{:.1}°C", t));
+    let voltage_str = format!("{:.2} V", voltage as f32 / 1000.0);
+    let amperage_str = format!("{} mA", amperage);
+    let rate_str = format!("{:.2} W", energy_rate.abs());
+
+    let lines = vec![
+        Line::from(vec![
+            Span::styled("Temp:       ", Style::default().fg(theme.muted)),
+            Span::styled(&temp_str, Style::default().fg(theme.fg)),
+            Span::styled("          Voltage:  ", Style::default().fg(theme.muted)),
+            Span::styled(&voltage_str, Style::default().fg(theme.fg)),
+        ]),
+        Line::from(vec![
+            Span::styled("Amperage:   ", Style::default().fg(theme.muted)),
+            Span::styled(&amperage_str, Style::default().fg(theme.fg)),
+            Span::styled("       Power:    ", Style::default().fg(theme.muted)),
+            Span::styled(&rate_str, Style::default().fg(theme.accent)),
+        ]),
+    ];
+
+    let paragraph = Paragraph::new(lines);
+    frame.render_widget(paragraph, area);
+}
+
+fn render_daily_soc(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeColors) {
+    let min_soc = app.battery.daily_min_soc();
+    let max_soc = app.battery.daily_max_soc();
+
+    let line = if let (Some(min), Some(max)) = (min_soc, max_soc) {
+        Line::from(vec![
+            Span::styled("Today:      ", Style::default().fg(theme.muted)),
+            Span::styled(format!("{:.0}%", min), Style::default().fg(theme.warning)),
+            Span::styled(" - ", Style::default().fg(theme.muted)),
+            Span::styled(format!("{:.0}%", max), Style::default().fg(theme.success)),
+            Span::styled(" (min - max)", Style::default().fg(theme.muted)),
+        ])
+    } else {
+        Line::from(vec![Span::styled(
+            "Today:      N/A (macOS only)",
+            Style::default().fg(theme.muted),
+        )])
+    };
+
+    let paragraph = Paragraph::new(vec![line]);
+    frame.render_widget(paragraph, area);
+}
+
+fn render_temperature_chart(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeColors) {
+    let block = Block::default()
+        .title(" Temperature ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.border))
+        .style(Style::default().bg(theme.dialog_bg));
+
+    let data = app.history.temperature_values();
+
+    if data.is_empty() {
+        frame.render_widget(block, area);
+        return;
+    }
+
+    let (min_y, max_y) = app.history.temperature_range();
+    let max_x = data.len().max(60) as f64;
+
+    let dataset = Dataset::default()
+        .marker(Marker::Braille)
+        .graph_type(GraphType::Line)
+        .style(Style::default().fg(theme.warning))
+        .data(&data);
+
+    let y_labels = vec![
+        Span::styled(format!("{:.0}°", min_y), Style::default().fg(theme.muted)),
+        Span::styled(format!("{:.0}°", max_y), Style::default().fg(theme.muted)),
+    ];
+
+    let x_axis = Axis::default()
+        .style(Style::default().fg(theme.muted))
+        .bounds([0.0, max_x]);
+
+    let y_axis = Axis::default()
+        .style(Style::default().fg(theme.muted))
+        .bounds([min_y, max_y])
+        .labels(y_labels);
+
+    let chart = Chart::new(vec![dataset])
+        .block(block)
+        .x_axis(x_axis)
+        .y_axis(y_axis)
+        .style(Style::default().bg(theme.dialog_bg));
+
+    frame.render_widget(chart, area);
+}
+
+fn render_footer(frame: &mut Frame, area: Rect, theme: &ThemeColors) {
+    let line = Line::from(vec![Span::styled(
+        "Press 'b' or Esc to close",
+        Style::default().fg(theme.muted),
+    )]);
+
+    let paragraph = Paragraph::new(vec![line]).centered();
+    frame.render_widget(paragraph, area);
+}

--- a/cli/src/ui/mod.rs
+++ b/cli/src/ui/mod.rs
@@ -1,4 +1,5 @@
 mod battery;
+mod battery_details;
 mod cycles;
 mod graphs;
 mod help;
@@ -142,6 +143,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         AppView::ThemeImporter => theme_importer::render(frame, app, &theme),
         AppView::History => history::render(frame, app, &theme),
         AppView::Settings => settings::render(frame, app, &theme),
+        AppView::BatteryDetails => battery_details::render(frame, app, &theme),
         AppView::Main => {}
     }
 }

--- a/crates/platform/src/battery.rs
+++ b/crates/platform/src/battery.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use color_eyre::eyre::Result;
 
-use crate::types::ChargeState;
+use crate::types::{BatteryTechnology, ChargeState};
 
 /// Battery information snapshot.
 ///
@@ -48,6 +48,24 @@ pub struct BatteryInfo {
 
     /// Whether external power is connected.
     pub external_connected: bool,
+
+    /// Battery vendor/manufacturer name (e.g., "Apple", "Samsung SDI").
+    pub vendor: Option<String>,
+
+    /// Battery model identifier (e.g., "bq20z451").
+    pub model: Option<String>,
+
+    /// Battery serial number.
+    pub serial_number: Option<String>,
+
+    /// Battery technology/chemistry type.
+    pub technology: BatteryTechnology,
+
+    /// Current energy remaining in watt-hours.
+    pub energy_wh: f32,
+
+    /// Instantaneous power rate in watts (positive = charging, negative = discharging).
+    pub energy_rate_watts: f32,
 
     // === macOS-specific fields (None on other platforms) ===
     /// Charger wattage rating (e.g., 96W), macOS only.

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -27,7 +27,7 @@ mod types;
 
 pub use battery::{BatteryInfo, BatteryProvider};
 pub use power::{PowerInfo, PowerProvider};
-pub use types::{ChargeState, PowerMode};
+pub use types::{BatteryTechnology, ChargeState, PowerMode};
 
 #[cfg(target_os = "macos")]
 #[cfg(feature = "macos")]

--- a/crates/platform/src/linux/battery.rs
+++ b/crates/platform/src/linux/battery.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use battery::units::electric_potential::millivolt;
 use battery::units::energy::watt_hour;
+use battery::units::power::watt;
 use battery::units::ratio::percent;
 use battery::units::thermodynamic_temperature::degree_celsius;
 use battery::units::time::second;
@@ -11,7 +12,7 @@ use battery::Manager;
 use color_eyre::eyre::{eyre, Result};
 
 use crate::battery::{BatteryInfo, BatteryProvider};
-use crate::types::ChargeState;
+use crate::types::{BatteryTechnology, ChargeState};
 
 const POWER_SUPPLY_PATH: &str = "/sys/class/power_supply";
 
@@ -77,6 +78,13 @@ impl LinuxBattery {
 
         let battery_state = battery.state();
         self.info.state = ChargeState::from(battery_state);
+
+        self.info.vendor = battery.vendor().map(|s| s.to_string());
+        self.info.model = battery.model().map(|s| s.to_string());
+        self.info.serial_number = battery.serial_number().map(|s| s.to_string());
+        self.info.technology = BatteryTechnology::from(battery.technology());
+        self.info.energy_wh = battery.energy().get::<watt_hour>();
+        self.info.energy_rate_watts = battery.energy_rate().get::<watt>();
 
         Ok(())
     }

--- a/crates/platform/src/macos/battery.rs
+++ b/crates/platform/src/macos/battery.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use battery::units::electric_potential::millivolt;
 use battery::units::energy::watt_hour;
+use battery::units::power::watt;
 use battery::units::ratio::percent;
 use battery::units::thermodynamic_temperature::degree_celsius;
 use battery::units::time::second;
@@ -10,7 +11,7 @@ use battery::Manager;
 use color_eyre::eyre::{eyre, Result};
 
 use crate::battery::{BatteryInfo, BatteryProvider};
-use crate::types::ChargeState;
+use crate::types::{BatteryTechnology, ChargeState};
 
 pub struct MacOSBattery {
     info: BatteryInfo,
@@ -64,6 +65,13 @@ impl MacOSBattery {
             .map(|t| Duration::from_secs(t.get::<second>() as u64));
 
         self.info.state = ChargeState::from(battery.state());
+
+        self.info.vendor = battery.vendor().map(|s| s.to_string());
+        self.info.model = battery.model().map(|s| s.to_string());
+        self.info.serial_number = battery.serial_number().map(|s| s.to_string());
+        self.info.technology = BatteryTechnology::from(battery.technology());
+        self.info.energy_wh = battery.energy().get::<watt_hour>();
+        self.info.energy_rate_watts = battery.energy_rate().get::<watt>();
 
         Ok(())
     }

--- a/crates/platform/src/types.rs
+++ b/crates/platform/src/types.rs
@@ -97,6 +97,72 @@ impl fmt::Display for PowerMode {
     }
 }
 
+/// Battery technology/chemistry type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BatteryTechnology {
+    /// Lithium-ion
+    LithiumIon,
+    /// Lithium-polymer
+    LithiumPolymer,
+    /// Nickel-metal hydride
+    NickelMetalHydride,
+    /// Nickel-cadmium
+    NickelCadmium,
+    /// Lead-acid
+    LeadAcid,
+    /// Unknown or unsupported technology
+    #[default]
+    Unknown,
+}
+
+impl BatteryTechnology {
+    /// Returns a human-readable label for the battery technology.
+    pub fn label(&self) -> &'static str {
+        match self {
+            BatteryTechnology::LithiumIon => "Li-ion",
+            BatteryTechnology::LithiumPolymer => "Li-poly",
+            BatteryTechnology::NickelMetalHydride => "NiMH",
+            BatteryTechnology::NickelCadmium => "NiCd",
+            BatteryTechnology::LeadAcid => "Lead-acid",
+            BatteryTechnology::Unknown => "Unknown",
+        }
+    }
+
+    /// Returns a longer description of the battery technology.
+    pub fn description(&self) -> &'static str {
+        match self {
+            BatteryTechnology::LithiumIon => "Lithium-ion",
+            BatteryTechnology::LithiumPolymer => "Lithium-polymer",
+            BatteryTechnology::NickelMetalHydride => "Nickel-metal hydride",
+            BatteryTechnology::NickelCadmium => "Nickel-cadmium",
+            BatteryTechnology::LeadAcid => "Lead-acid",
+            BatteryTechnology::Unknown => "Unknown",
+        }
+    }
+}
+
+impl fmt::Display for BatteryTechnology {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.label())
+    }
+}
+
+/// Convert from battery crate Technology to our BatteryTechnology.
+impl From<battery::Technology> for BatteryTechnology {
+    fn from(tech: battery::Technology) -> Self {
+        match tech {
+            battery::Technology::LithiumIon => BatteryTechnology::LithiumIon,
+            battery::Technology::LithiumPolymer => BatteryTechnology::LithiumPolymer,
+            battery::Technology::NickelMetalHydride => BatteryTechnology::NickelMetalHydride,
+            battery::Technology::NickelCadmium => BatteryTechnology::NickelCadmium,
+            battery::Technology::LeadAcid => BatteryTechnology::LeadAcid,
+            battery::Technology::Unknown => BatteryTechnology::Unknown,
+            // Handle any future variants
+            _ => BatteryTechnology::Unknown,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

Implements issues #50 and #12 - adds a comprehensive battery details popup and enhances graph aesthetics.

### Battery Details Popup (press `b`)
- **Device info**: vendor, model, serial number, technology type
- **Charge section**: current charge with visual gauge, health percentage, cycle count
- **Readings section**: temperature, voltage, amperage
- **Daily SoC range**: min/max battery levels for the day (macOS)
- **Temperature chart**: mini sparkline showing recent temperature history

### Graph Improvements
- **Side-by-side layout**: main graph (60%) + temperature chart (40%) when terminal width >= 80
- **Stacked layout**: fallback for narrow terminals
- **Grid lines**: horizontal reference lines at quarter intervals
- **Better Y-axis**: 5 tick marks instead of 2
- **Time labels**: X-axis shows "now", "-30s", "-60s"
- **Min/max markers**: ▲ for highest point, ▼ for lowest
- **Threshold line**: 20% battery warning line (danger color)

### Platform Layer
- Added `BatteryTechnology` enum (LithiumIon, LithiumPolymer, NickelMetalHydride, etc.)
- Extended `BatteryInfo` struct with vendor/model/serial/technology/energy fields
- Updated macOS and Linux providers to extract new fields

## Changes
- 14 files changed, +810/-57 lines
- New file: `cli/src/ui/battery_details.rs` (288 lines)

## Testing
- ✅ `cargo build` passes
- ✅ `cargo clippy` - no warnings  
- ✅ `cargo test` - 44 tests pass

Fixes #50, fixes #12