### PR TITLE
refactor(ui): extract inline text gauge to helper function

### DIFF
--- a/cli/src/ui/battery_details.rs
+++ b/cli/src/ui/battery_details.rs
@@ -28,6 +28,13 @@ fn color_for_percent(percent: f32, high: f32, low: f32, theme: &ThemeColors) -> 
     }
 }
 
+fn text_gauge(percent: f32, width: usize, color: Color) -> Span<'static> {
+    let filled = ((percent / 100.0) * width as f32) as usize;
+    let empty = width.saturating_sub(filled);
+    let gauge_str = format!("{}{}", "█".repeat(filled), "░".repeat(empty));
+    Span::styled(gauge_str, Style::default().fg(color))
+}
+
 pub fn render(frame: &mut Frame, app: &App, theme: &ThemeColors) {
     let popup_width = 70;
     let popup_height = 28;
@@ -109,11 +116,6 @@ fn render_charge_info(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeCol
 
     let percent_color = color_for_percent(percent, 50.0, 20.0, theme);
 
-    let gauge_width = 20;
-    let filled = ((percent / 100.0) * gauge_width as f32) as usize;
-    let empty = gauge_width - filled;
-    let gauge_str = format!("{}{}", "█".repeat(filled), "░".repeat(empty));
-
     let lines = vec![
         Line::from(vec![
             Span::styled("Charge:     ", Style::default().fg(theme.muted)),
@@ -124,7 +126,7 @@ fn render_charge_info(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeCol
                     .add_modifier(Modifier::BOLD),
             ),
             Span::styled("  ", Style::default()),
-            Span::styled(&gauge_str, Style::default().fg(percent_color)),
+            text_gauge(percent, 20, percent_color),
             Span::styled(
                 format!("  ({:.1} Wh)", energy),
                 Style::default().fg(theme.muted),


### PR DESCRIPTION
## Summary

- Extracts inline text gauge code in `battery_details.rs` to a reusable `text_gauge()` helper function
- Follows the pattern established in PR #54 which replaced the custom `ThickGauge` with ratatui's `Gauge` widget

## Context

After auditing the UI codebase for custom components that could use ratatui widgets, this was the only remaining candidate. The text gauge uses Unicode block characters (`█` and `░`) to display an inline progress bar within `Paragraph` text.

Unlike the main battery gauge (which now uses ratatui's `Gauge` widget), this inline gauge cannot use ratatui widgets directly since those require their own `Rect` - it needs to remain as a `Span` embedded in text.

## Changes

**File**: `cli/src/ui/battery_details.rs`

```rust
fn text_gauge(percent: f32, width: usize, color: Color) -> Span<'static> {
    let filled = ((percent / 100.0) * width as f32) as usize;
    let empty = width.saturating_sub(filled);
    let gauge_str = format!("{}{}", "█".repeat(filled), "░".repeat(empty));
    Span::styled(gauge_str, Style::default().fg(color))
}
```

## Verification

- [x] `cargo check` - passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - no warnings
- [x] `cargo build --release` - success