### PR TITLE
refactor(ui): add ThemeColors style helpers and simplify UI styling

### DIFF
--- a/cli/src/theme/mod.rs
+++ b/cli/src/theme/mod.rs
@@ -1,7 +1,7 @@
 // UI adapter: converts jolt-theme colors to ratatui colors
 // The actual theme logic lives in the jolt-theme crate
 
-use ratatui::style::Color as RatatuiColor;
+use ratatui::style::{Color as RatatuiColor, Style};
 
 pub use jolt_theme::Color;
 
@@ -47,4 +47,62 @@ impl From<jolt_theme::ThemeColors> for ThemeColors {
 
 fn to_ratatui_color(color: Color) -> RatatuiColor {
     RatatuiColor::Rgb(color.r, color.g, color.b)
+}
+
+impl ThemeColors {
+    #[inline]
+    #[allow(dead_code)]
+    pub fn style(&self, color: RatatuiColor) -> Style {
+        Style::default().fg(color)
+    }
+
+    #[inline]
+    pub fn fg_style(&self) -> Style {
+        Style::default().fg(self.fg)
+    }
+
+    #[inline]
+    pub fn muted_style(&self) -> Style {
+        Style::default().fg(self.muted)
+    }
+
+    #[inline]
+    pub fn accent_style(&self) -> Style {
+        Style::default().fg(self.accent)
+    }
+
+    #[inline]
+    pub fn accent_secondary_style(&self) -> Style {
+        Style::default().fg(self.accent_secondary)
+    }
+
+    #[inline]
+    pub fn highlight_style(&self) -> Style {
+        Style::default().fg(self.highlight)
+    }
+
+    #[inline]
+    pub fn success_style(&self) -> Style {
+        Style::default().fg(self.success)
+    }
+
+    #[inline]
+    pub fn warning_style(&self) -> Style {
+        Style::default().fg(self.warning)
+    }
+
+    #[inline]
+    pub fn danger_style(&self) -> Style {
+        Style::default().fg(self.danger)
+    }
+
+    #[inline]
+    pub fn border_style(&self) -> Style {
+        Style::default().fg(self.border)
+    }
+
+    #[inline]
+    pub fn graph_style(&self) -> Style {
+        Style::default().fg(self.graph_line)
+    }
 }

--- a/cli/src/ui/battery.rs
+++ b/cli/src/ui/battery.rs
@@ -40,7 +40,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeColors) {
     let block = Block::default()
         .title(" Battery ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme.border))
+        .border_style(theme.border_style())
         .style(Style::default().bg(theme.bg));
 
     let inner = block.inner(area);
@@ -200,22 +200,19 @@ fn render_battery_info_card(frame: &mut Frame, area: Rect, app: &App, theme: &Th
             .split(inner);
 
         let mut row1_spans = vec![
-            Span::styled(
-                format!("{} ", state_icon),
-                Style::default().fg(theme.accent),
-            ),
+            Span::styled(format!("{} ", state_icon), theme.accent_style()),
             Span::styled(
                 app.battery.state_label(),
-                Style::default().fg(theme.fg).add_modifier(Modifier::BOLD),
+                theme.fg_style().add_modifier(Modifier::BOLD),
             ),
-            Span::styled("  │  ", Style::default().fg(theme.border)),
-            Span::styled(format!("{} ", time_label), Style::default().fg(theme.muted)),
-            Span::styled(&time_value, Style::default().fg(theme.fg)),
+            Span::styled("  │  ", theme.border_style()),
+            Span::styled(format!("{} ", time_label), theme.muted_style()),
+            Span::styled(&time_value, theme.fg_style()),
         ];
 
         if let Some((ref text, has_value)) = forecast_info {
-            row1_spans.push(Span::styled("  │  ", Style::default().fg(theme.border)));
-            row1_spans.push(Span::styled("Forecast: ", Style::default().fg(theme.muted)));
+            row1_spans.push(Span::styled("  │  ", theme.border_style()));
+            row1_spans.push(Span::styled("Forecast: ", theme.muted_style()));
             let color = if has_value {
                 theme.success
             } else {
@@ -226,13 +223,13 @@ fn render_battery_info_card(frame: &mut Frame, area: Rect, app: &App, theme: &Th
 
         row1_spans.push(Span::styled(
             power_text.map_or(String::new(), |p| format!("  │  {}", p)),
-            Style::default().fg(theme.accent),
+            theme.accent_style(),
         ));
 
         let row1 = Line::from(row1_spans);
 
         let mut row2_spans = vec![
-            Span::styled("Health: ", Style::default().fg(theme.muted)),
+            Span::styled("Health: ", theme.muted_style()),
             Span::styled(
                 format!("{:.0}%", app.battery.health_percent()),
                 Style::default().fg(health_color),
@@ -243,42 +240,42 @@ fn render_battery_info_card(frame: &mut Frame, area: Rect, app: &App, theme: &Th
                     app.battery.max_capacity_wh(),
                     app.battery.design_capacity_wh()
                 ),
-                Style::default().fg(theme.muted),
+                theme.muted_style(),
             ),
-            Span::styled("  │  ", Style::default().fg(theme.border)),
-            Span::styled("Cycles: ", Style::default().fg(theme.muted)),
-            Span::styled(&cycles_text, Style::default().fg(theme.fg)),
+            Span::styled("  │  ", theme.border_style()),
+            Span::styled("Cycles: ", theme.muted_style()),
+            Span::styled(&cycles_text, theme.fg_style()),
         ];
 
         if let Some(temp) = app.battery.temperature_c() {
-            row2_spans.push(Span::styled("  │  ", Style::default().fg(theme.border)));
+            row2_spans.push(Span::styled("  │  ", theme.border_style()));
             row2_spans.push(Span::styled(
                 format!("{:.1}°C", temp),
-                Style::default().fg(theme.warning),
+                theme.warning_style(),
             ));
         }
 
-        row2_spans.push(Span::styled("  │  ", Style::default().fg(theme.border)));
+        row2_spans.push(Span::styled("  │  ", theme.border_style()));
         row2_spans.push(Span::styled(
             format!("{:.1}Wh", app.battery.energy_wh()),
-            Style::default().fg(theme.fg),
+            theme.fg_style(),
         ));
 
         if let (Some(min), Some(max)) = (app.battery.daily_min_soc(), app.battery.daily_max_soc()) {
-            row2_spans.push(Span::styled("  │  ", Style::default().fg(theme.border)));
+            row2_spans.push(Span::styled("  │  ", theme.border_style()));
             row2_spans.push(Span::styled(
                 format!("{:.0}-{:.0}%", min, max),
-                Style::default().fg(theme.muted),
+                theme.muted_style(),
             ));
         }
 
         if app.power.power_mode() != PowerMode::Unknown {
             let mode_icon = power_mode_icon(app.power.power_mode());
-            row2_spans.push(Span::styled("  │  ", Style::default().fg(theme.border)));
-            row2_spans.push(Span::styled("Mode: ", Style::default().fg(theme.muted)));
+            row2_spans.push(Span::styled("  │  ", theme.border_style()));
+            row2_spans.push(Span::styled("Mode: ", theme.muted_style()));
             row2_spans.push(Span::styled(
                 format!("{} {}", mode_icon, app.power.power_mode_label()),
-                Style::default().fg(theme.fg),
+                theme.fg_style(),
             ));
         }
 
@@ -306,19 +303,16 @@ fn build_single_line<'a>(
     health_color: ratatui::style::Color,
 ) -> Line<'a> {
     let mut spans = vec![
-        Span::styled(format!("{} ", icon), Style::default().fg(theme.accent)),
-        Span::styled(
-            state,
-            Style::default().fg(theme.fg).add_modifier(Modifier::BOLD),
-        ),
-        Span::styled("  │  ", Style::default().fg(theme.border)),
-        Span::styled(format!("{} ", time_label), Style::default().fg(theme.muted)),
-        Span::styled(time_value, Style::default().fg(theme.fg)),
+        Span::styled(format!("{} ", icon), theme.accent_style()),
+        Span::styled(state, theme.fg_style().add_modifier(Modifier::BOLD)),
+        Span::styled("  │  ", theme.border_style()),
+        Span::styled(format!("{} ", time_label), theme.muted_style()),
+        Span::styled(time_value, theme.fg_style()),
     ];
 
     if let Some((text, has_value)) = forecast {
-        spans.push(Span::styled("  │  ", Style::default().fg(theme.border)));
-        spans.push(Span::styled("Forecast: ", Style::default().fg(theme.muted)));
+        spans.push(Span::styled("  │  ", theme.border_style()));
+        spans.push(Span::styled("Forecast: ", theme.muted_style()));
         let color = if has_value {
             theme.success
         } else {
@@ -328,31 +322,28 @@ fn build_single_line<'a>(
     }
 
     if let Some(p) = power {
-        spans.push(Span::styled(
-            format!("  │  {}", p),
-            Style::default().fg(theme.accent),
-        ));
+        spans.push(Span::styled(format!("  │  {}", p), theme.accent_style()));
     }
 
     spans.extend([
-        Span::styled("  │  ", Style::default().fg(theme.border)),
+        Span::styled("  │  ", theme.border_style()),
         Span::styled(
             format!("health {:.0}%", health),
             Style::default().fg(health_color),
         ),
         Span::styled(
             format!(" ({:.0}/{:.0}Wh)", capacity, design_capacity),
-            Style::default().fg(theme.muted),
+            theme.muted_style(),
         ),
-        Span::styled("  │  ", Style::default().fg(theme.border)),
-        Span::styled(cycles, Style::default().fg(theme.fg)),
-        Span::styled(" cycles", Style::default().fg(theme.muted)),
+        Span::styled("  │  ", theme.border_style()),
+        Span::styled(cycles, theme.fg_style()),
+        Span::styled(" cycles", theme.muted_style()),
     ]);
 
     if let Some(mode) = power_mode {
-        spans.push(Span::styled("  │  ", Style::default().fg(theme.border)));
-        spans.push(Span::styled("Mode: ", Style::default().fg(theme.muted)));
-        spans.push(Span::styled(mode, Style::default().fg(theme.fg)));
+        spans.push(Span::styled("  │  ", theme.border_style()));
+        spans.push(Span::styled("Mode: ", theme.muted_style()));
+        spans.push(Span::styled(mode, theme.fg_style()));
     }
 
     Line::from(spans)

--- a/cli/src/ui/battery_details.rs
+++ b/cli/src/ui/battery_details.rs
@@ -45,7 +45,7 @@ pub fn render(frame: &mut Frame, app: &App, theme: &ThemeColors) {
     let block = Block::default()
         .title(" Battery Details ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme.accent))
+        .border_style(theme.accent_style())
         .style(Style::default().bg(theme.dialog_bg));
 
     let inner = block.inner(area);
@@ -89,18 +89,18 @@ fn render_device_info(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeCol
 
     let lines = vec![
         Line::from(vec![
-            Span::styled("Vendor:     ", Style::default().fg(theme.muted)),
-            Span::styled(vendor, Style::default().fg(theme.fg)),
-            Span::styled("          Model:  ", Style::default().fg(theme.muted)),
-            Span::styled(model, Style::default().fg(theme.fg)),
+            Span::styled("Vendor:     ", theme.muted_style()),
+            Span::styled(vendor, theme.fg_style()),
+            Span::styled("          Model:  ", theme.muted_style()),
+            Span::styled(model, theme.fg_style()),
         ]),
         Line::from(vec![
-            Span::styled("Serial:     ", Style::default().fg(theme.muted)),
-            Span::styled(serial, Style::default().fg(theme.fg)),
+            Span::styled("Serial:     ", theme.muted_style()),
+            Span::styled(serial, theme.fg_style()),
         ]),
         Line::from(vec![
-            Span::styled("Technology: ", Style::default().fg(theme.muted)),
-            Span::styled(technology, Style::default().fg(theme.fg)),
+            Span::styled("Technology: ", theme.muted_style()),
+            Span::styled(technology, theme.fg_style()),
         ]),
     ];
 
@@ -118,7 +118,7 @@ fn render_charge_info(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeCol
 
     let lines = vec![
         Line::from(vec![
-            Span::styled("Charge:     ", Style::default().fg(theme.muted)),
+            Span::styled("Charge:     ", theme.muted_style()),
             Span::styled(
                 format!("{:.1}%", percent),
                 Style::default()
@@ -127,17 +127,14 @@ fn render_charge_info(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeCol
             ),
             Span::styled("  ", Style::default()),
             text_gauge(percent, 20, percent_color),
-            Span::styled(
-                format!("  ({:.1} Wh)", energy),
-                Style::default().fg(theme.muted),
-            ),
+            Span::styled(format!("  ({:.1} Wh)", energy), theme.muted_style()),
         ]),
         Line::from(vec![
-            Span::styled("Status:     ", Style::default().fg(theme.muted)),
-            Span::styled(state, Style::default().fg(theme.fg)),
+            Span::styled("Status:     ", theme.muted_style()),
+            Span::styled(state, theme.fg_style()),
             Span::styled(
                 format!("          Capacity: {:.1} Wh", max_capacity),
-                Style::default().fg(theme.muted),
+                theme.muted_style(),
             ),
         ]),
     ];
@@ -158,7 +155,7 @@ fn render_health_info(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeCol
 
     let lines = vec![
         Line::from(vec![
-            Span::styled("Health:     ", Style::default().fg(theme.muted)),
+            Span::styled("Health:     ", theme.muted_style()),
             Span::styled(
                 format!("{:.1}%", health),
                 Style::default()
@@ -167,12 +164,12 @@ fn render_health_info(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeCol
             ),
             Span::styled(
                 format!("  ({:.1} / {:.1} Wh)", max_capacity, design_capacity),
-                Style::default().fg(theme.muted),
+                theme.muted_style(),
             ),
         ]),
         Line::from(vec![
-            Span::styled("Cycles:     ", Style::default().fg(theme.muted)),
-            Span::styled(&cycles_str, Style::default().fg(theme.fg)),
+            Span::styled("Cycles:     ", theme.muted_style()),
+            Span::styled(&cycles_str, theme.fg_style()),
         ]),
     ];
 
@@ -193,16 +190,16 @@ fn render_electrical_info(frame: &mut Frame, area: Rect, app: &App, theme: &Them
 
     let lines = vec![
         Line::from(vec![
-            Span::styled("Temp:       ", Style::default().fg(theme.muted)),
-            Span::styled(&temp_str, Style::default().fg(theme.fg)),
-            Span::styled("          Voltage:  ", Style::default().fg(theme.muted)),
-            Span::styled(&voltage_str, Style::default().fg(theme.fg)),
+            Span::styled("Temp:       ", theme.muted_style()),
+            Span::styled(&temp_str, theme.fg_style()),
+            Span::styled("          Voltage:  ", theme.muted_style()),
+            Span::styled(&voltage_str, theme.fg_style()),
         ]),
         Line::from(vec![
-            Span::styled("Amperage:   ", Style::default().fg(theme.muted)),
-            Span::styled(&amperage_str, Style::default().fg(theme.fg)),
-            Span::styled("       Power:    ", Style::default().fg(theme.muted)),
-            Span::styled(&rate_str, Style::default().fg(theme.accent)),
+            Span::styled("Amperage:   ", theme.muted_style()),
+            Span::styled(&amperage_str, theme.fg_style()),
+            Span::styled("       Power:    ", theme.muted_style()),
+            Span::styled(&rate_str, theme.accent_style()),
         ]),
     ];
 
@@ -216,16 +213,16 @@ fn render_daily_soc(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeColor
 
     let line = if let (Some(min), Some(max)) = (min_soc, max_soc) {
         Line::from(vec![
-            Span::styled("Today:      ", Style::default().fg(theme.muted)),
-            Span::styled(format!("{:.0}%", min), Style::default().fg(theme.warning)),
-            Span::styled(" - ", Style::default().fg(theme.muted)),
-            Span::styled(format!("{:.0}%", max), Style::default().fg(theme.success)),
-            Span::styled(" (min - max)", Style::default().fg(theme.muted)),
+            Span::styled("Today:      ", theme.muted_style()),
+            Span::styled(format!("{:.0}%", min), theme.warning_style()),
+            Span::styled(" - ", theme.muted_style()),
+            Span::styled(format!("{:.0}%", max), theme.success_style()),
+            Span::styled(" (min - max)", theme.muted_style()),
         ])
     } else {
         Line::from(vec![Span::styled(
             "Today:      N/A (macOS only)",
-            Style::default().fg(theme.muted),
+            theme.muted_style(),
         )])
     };
 
@@ -237,7 +234,7 @@ fn render_temperature_chart(frame: &mut Frame, area: Rect, app: &App, theme: &Th
     let block = Block::default()
         .title(" Temperature ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme.border))
+        .border_style(theme.border_style())
         .style(Style::default().bg(theme.dialog_bg));
 
     let data = app.history.temperature_values();
@@ -253,20 +250,20 @@ fn render_temperature_chart(frame: &mut Frame, area: Rect, app: &App, theme: &Th
     let dataset = Dataset::default()
         .marker(Marker::Braille)
         .graph_type(GraphType::Line)
-        .style(Style::default().fg(theme.warning))
+        .style(theme.warning_style())
         .data(&data);
 
     let y_labels = vec![
-        Span::styled(format!("{:.0}°", min_y), Style::default().fg(theme.muted)),
-        Span::styled(format!("{:.0}°", max_y), Style::default().fg(theme.muted)),
+        Span::styled(format!("{:.0}°", min_y), theme.muted_style()),
+        Span::styled(format!("{:.0}°", max_y), theme.muted_style()),
     ];
 
     let x_axis = Axis::default()
-        .style(Style::default().fg(theme.muted))
+        .style(theme.muted_style())
         .bounds([0.0, max_x]);
 
     let y_axis = Axis::default()
-        .style(Style::default().fg(theme.muted))
+        .style(theme.muted_style())
         .bounds([min_y, max_y])
         .labels(y_labels);
 
@@ -282,7 +279,7 @@ fn render_temperature_chart(frame: &mut Frame, area: Rect, app: &App, theme: &Th
 fn render_footer(frame: &mut Frame, area: Rect, theme: &ThemeColors) {
     let line = Line::from(vec![Span::styled(
         "Press 'b' or Esc to close",
-        Style::default().fg(theme.muted),
+        theme.muted_style(),
     )]);
 
     let paragraph = Paragraph::new(vec![line]).centered();

--- a/cli/src/ui/cycles.rs
+++ b/cli/src/ui/cycles.rs
@@ -14,7 +14,7 @@ pub fn render_cycle_summary(frame: &mut Frame, area: Rect, app: &App, theme: &Th
     let block = Block::default()
         .title(" Battery Cycles ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme.border));
+        .border_style(theme.border_style());
 
     let inner = block.inner(area);
     frame.render_widget(block, area);
@@ -22,7 +22,7 @@ pub fn render_cycle_summary(frame: &mut Frame, area: Rect, app: &App, theme: &Th
     let Some(ref summary) = app.cycle_summary else {
         let no_data = Paragraph::new(vec![Line::from(vec![Span::styled(
             "No cycle data",
-            Style::default().fg(theme.muted),
+            theme.muted_style(),
         )])])
         .centered();
         frame.render_widget(no_data, inner);
@@ -36,7 +36,7 @@ pub fn render_cycle_summary(frame: &mut Frame, area: Rect, app: &App, theme: &Th
 
     let left_stats = vec![
         Line::from(vec![
-            Span::styled("macOS Cycles:   ", Style::default().fg(theme.muted)),
+            Span::styled("macOS Cycles:   ", theme.muted_style()),
             Span::styled(
                 format!("{}", summary.total_cycles_macos),
                 Style::default()
@@ -45,14 +45,14 @@ pub fn render_cycle_summary(frame: &mut Frame, area: Rect, app: &App, theme: &Th
             ),
         ]),
         Line::from(vec![
-            Span::styled("Partial Cycles: ", Style::default().fg(theme.muted)),
+            Span::styled("Partial Cycles: ", theme.muted_style()),
             Span::styled(
                 format!("{:.2}", summary.partial_cycles_calculated),
-                Style::default().fg(theme.fg),
+                theme.fg_style(),
             ),
         ]),
         Line::from(vec![
-            Span::styled("Avg Daily:      ", Style::default().fg(theme.muted)),
+            Span::styled("Avg Daily:      ", theme.muted_style()),
             Span::styled(
                 format!("{:.2}/day", summary.avg_daily_cycles),
                 Style::default().fg(cycle_rate_color(summary.avg_daily_cycles, theme)),
@@ -62,21 +62,21 @@ pub fn render_cycle_summary(frame: &mut Frame, area: Rect, app: &App, theme: &Th
 
     let right_stats = vec![
         Line::from(vec![
-            Span::styled("Avg DoD:        ", Style::default().fg(theme.muted)),
+            Span::styled("Avg DoD:        ", theme.muted_style()),
             Span::styled(
                 format!("{:.0}%", summary.avg_depth_of_discharge),
                 Style::default().fg(dod_color(summary.avg_depth_of_discharge, theme)),
             ),
         ]),
         Line::from(vec![
-            Span::styled("Charges/Day:    ", Style::default().fg(theme.muted)),
+            Span::styled("Charges/Day:    ", theme.muted_style()),
             Span::styled(
                 format!("{:.1}", summary.avg_charge_sessions_per_day),
-                Style::default().fg(theme.fg),
+                theme.fg_style(),
             ),
         ]),
         Line::from(vec![
-            Span::styled("Time >80%:      ", Style::default().fg(theme.muted)),
+            Span::styled("Time >80%:      ", theme.muted_style()),
             Span::styled(
                 format!("{:.0}%", summary.time_at_high_soc_percent),
                 Style::default().fg(high_soc_color(summary.time_at_high_soc_percent, theme)),
@@ -97,7 +97,7 @@ pub fn render_recent_sessions(frame: &mut Frame, area: Rect, app: &App, theme: &
     let block = Block::default()
         .title(" Recent Charge Sessions ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme.border));
+        .border_style(theme.border_style());
 
     let inner = block.inner(area);
     frame.render_widget(block, area);
@@ -105,7 +105,7 @@ pub fn render_recent_sessions(frame: &mut Frame, area: Rect, app: &App, theme: &
     if app.recent_charge_sessions.is_empty() {
         let no_data = Paragraph::new(vec![Line::from(vec![Span::styled(
             "No sessions recorded",
-            Style::default().fg(theme.muted),
+            theme.muted_style(),
         )])])
         .centered();
         frame.render_widget(no_data, inner);

--- a/cli/src/ui/graphs.rs
+++ b/cli/src/ui/graphs.rs
@@ -21,9 +21,9 @@ fn horizontal_line_points(y_value: f64, max_x: f64) -> Vec<(f64, f64)> {
 fn x_axis_time_labels(data_len: usize, theme: &ThemeColors) -> Vec<Span<'static>> {
     let max_x = data_len.max(60);
     vec![
-        Span::styled("now", Style::default().fg(theme.muted)),
-        Span::styled(format!("-{}s", max_x / 2), Style::default().fg(theme.muted)),
-        Span::styled(format!("-{}s", max_x), Style::default().fg(theme.muted)),
+        Span::styled("now", theme.muted_style()),
+        Span::styled(format!("-{}s", max_x / 2), theme.muted_style()),
+        Span::styled(format!("-{}s", max_x), theme.muted_style()),
     ]
 }
 
@@ -80,22 +80,17 @@ fn render_temperature_chart(frame: &mut Frame, area: Rect, app: &App, theme: &Th
     let current_temp = app.history.latest_temperature();
 
     let title_line = Line::from(vec![
-        Span::styled(
-            " Temp ",
-            Style::default()
-                .fg(theme.warning)
-                .add_modifier(Modifier::BOLD),
-        ),
+        Span::styled(" Temp ", theme.warning_style().add_modifier(Modifier::BOLD)),
         Span::styled(
             current_temp.map_or("--".to_string(), |t| format!("{:.1}°C", t)),
-            Style::default().fg(theme.fg),
+            theme.fg_style(),
         ),
     ]);
 
     let block = Block::default()
         .title(title_line)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme.border))
+        .border_style(theme.border_style())
         .style(Style::default().bg(theme.bg));
 
     if temp_data.is_empty() {
@@ -123,25 +118,25 @@ fn render_temperature_chart(frame: &mut Frame, area: Rect, app: &App, theme: &Th
         Dataset::default()
             .marker(Marker::Braille)
             .graph_type(GraphType::Line)
-            .style(Style::default().fg(theme.warning))
+            .style(theme.warning_style())
             .data(&temp_data),
     );
 
     let x_labels = x_axis_time_labels(temp_data.len(), theme);
 
     let y_labels = vec![
-        Span::styled(format!("{:.0}°", min_y), Style::default().fg(theme.muted)),
-        Span::styled(format!("{:.0}°", mid_y), Style::default().fg(theme.muted)),
-        Span::styled(format!("{:.0}°", max_y), Style::default().fg(theme.muted)),
+        Span::styled(format!("{:.0}°", min_y), theme.muted_style()),
+        Span::styled(format!("{:.0}°", mid_y), theme.muted_style()),
+        Span::styled(format!("{:.0}°", max_y), theme.muted_style()),
     ];
 
     let x_axis = Axis::default()
-        .style(Style::default().fg(theme.muted))
+        .style(theme.muted_style())
         .bounds([0.0, max_x])
         .labels(x_labels);
 
     let y_axis = Axis::default()
-        .style(Style::default().fg(theme.muted))
+        .style(theme.muted_style())
         .bounds([min_y, max_y])
         .labels(y_labels);
 
@@ -194,26 +189,18 @@ fn render_single(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeColors) 
     let title_line = Line::from(vec![
         Span::styled(
             format!(" {} ", app.history.metric_label()),
-            Style::default()
-                .fg(theme.accent)
-                .add_modifier(Modifier::BOLD),
+            theme.accent_style().add_modifier(Modifier::BOLD),
         ),
-        Span::styled(
-            current_value.unwrap_or_default(),
-            Style::default().fg(theme.fg),
-        ),
+        Span::styled(current_value.unwrap_or_default(), theme.fg_style()),
         Span::styled(" ", Style::default()),
-        Span::styled(
-            avg_value.unwrap_or_default(),
-            Style::default().fg(theme.muted),
-        ),
-        Span::styled(" (g: toggle) ", Style::default().fg(theme.muted)),
+        Span::styled(avg_value.unwrap_or_default(), theme.muted_style()),
+        Span::styled(" (g: toggle) ", theme.muted_style()),
     ]);
 
     let block = Block::default()
         .title(title_line)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme.border))
+        .border_style(theme.border_style())
         .style(Style::default().bg(theme.bg));
 
     let data = app.history.current_values();
@@ -249,7 +236,7 @@ fn render_single(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeColors) 
             Dataset::default()
                 .marker(Marker::Braille)
                 .graph_type(GraphType::Line)
-                .style(Style::default().fg(theme.danger))
+                .style(theme.danger_style())
                 .data(Box::leak(threshold_data.into_boxed_slice())),
         );
     }
@@ -258,36 +245,27 @@ fn render_single(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeColors) 
         Dataset::default()
             .marker(Marker::Braille)
             .graph_type(GraphType::Line)
-            .style(Style::default().fg(theme.graph_line))
+            .style(theme.graph_style())
             .data(&data),
     );
 
     let x_labels = x_axis_time_labels(data.len(), theme);
 
     let y_labels = vec![
-        Span::styled(format!("{:.0}", min_y), Style::default().fg(theme.muted)),
-        Span::styled(
-            format!("{:.0}", min_y + quarter),
-            Style::default().fg(theme.muted),
-        ),
-        Span::styled(
-            format!("{:.0}", min_y + quarter * 2.0),
-            Style::default().fg(theme.muted),
-        ),
-        Span::styled(
-            format!("{:.0}", min_y + quarter * 3.0),
-            Style::default().fg(theme.muted),
-        ),
-        Span::styled(format!("{:.0}", max_y), Style::default().fg(theme.muted)),
+        Span::styled(format!("{:.0}", min_y), theme.muted_style()),
+        Span::styled(format!("{:.0}", min_y + quarter), theme.muted_style()),
+        Span::styled(format!("{:.0}", min_y + quarter * 2.0), theme.muted_style()),
+        Span::styled(format!("{:.0}", min_y + quarter * 3.0), theme.muted_style()),
+        Span::styled(format!("{:.0}", max_y), theme.muted_style()),
     ];
 
     let x_axis = Axis::default()
-        .style(Style::default().fg(theme.muted))
+        .style(theme.muted_style())
         .bounds([0.0, max_x])
         .labels(x_labels);
 
     let y_axis = Axis::default()
-        .style(Style::default().fg(theme.muted))
+        .style(theme.muted_style())
         .bounds([min_y, max_y])
         .labels(y_labels);
 
@@ -329,7 +307,7 @@ fn render_battery_markers(
 
         if x < inner.x + inner.width && y >= inner.y && y < inner.y + inner.height {
             let marker = Paragraph::new(format!("{:.0}", change.value))
-                .style(Style::default().fg(theme.accent_secondary));
+                .style(theme.accent_secondary_style());
             let marker_area = Rect::new(x.saturating_sub(1), y.saturating_sub(1), 4, 1);
             frame.render_widget(marker, marker_area);
         }
@@ -353,26 +331,21 @@ fn render_merged(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeColors) 
     let title_line = Line::from(vec![
         Span::styled(
             " Combined ",
-            Style::default()
-                .fg(theme.accent)
-                .add_modifier(Modifier::BOLD),
+            theme.accent_style().add_modifier(Modifier::BOLD),
         ),
-        Span::styled(
-            format!("{:.1}W", power_val),
-            Style::default().fg(theme.graph_line),
-        ),
-        Span::styled(" │ ", Style::default().fg(theme.border)),
+        Span::styled(format!("{:.1}W", power_val), theme.graph_style()),
+        Span::styled(" │ ", theme.border_style()),
         Span::styled(
             format!("{:.0}%", battery_val),
-            Style::default().fg(theme.accent_secondary),
+            theme.accent_secondary_style(),
         ),
-        Span::styled(" (g: toggle) ", Style::default().fg(theme.muted)),
+        Span::styled(" (g: toggle) ", theme.muted_style()),
     ]);
 
     let block = Block::default()
         .title(title_line)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme.border))
+        .border_style(theme.border_style())
         .style(Style::default().bg(theme.bg));
 
     let power_data = app.history.power_values();
@@ -412,7 +385,7 @@ fn render_merged(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeColors) 
             .name("Power")
             .marker(Marker::Braille)
             .graph_type(GraphType::Line)
-            .style(Style::default().fg(theme.graph_line))
+            .style(theme.graph_style())
             .data(&power_data),
     );
 
@@ -421,28 +394,28 @@ fn render_merged(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeColors) 
             .name("Battery")
             .marker(Marker::Braille)
             .graph_type(GraphType::Line)
-            .style(Style::default().fg(theme.accent_secondary))
+            .style(theme.accent_secondary_style())
             .data(&battery_data),
     );
 
     let x_labels = x_axis_time_labels(power_data.len(), theme);
 
     let y_labels = vec![
-        Span::styled(format!("{:.0}W", min_y), Style::default().fg(theme.muted)),
+        Span::styled(format!("{:.0}W", min_y), theme.muted_style()),
         Span::styled(
             format!("{:.0}W", min_y + quarter * 2.0),
-            Style::default().fg(theme.muted),
+            theme.muted_style(),
         ),
-        Span::styled(format!("{:.0}W", max_y), Style::default().fg(theme.muted)),
+        Span::styled(format!("{:.0}W", max_y), theme.muted_style()),
     ];
 
     let x_axis = Axis::default()
-        .style(Style::default().fg(theme.muted))
+        .style(theme.muted_style())
         .bounds([0.0, max_x])
         .labels(x_labels);
 
     let y_axis = Axis::default()
-        .style(Style::default().fg(theme.muted))
+        .style(theme.muted_style())
         .bounds([min_y, max_y])
         .labels(y_labels);
 
@@ -494,7 +467,7 @@ fn render_mini_chart(
     let block = Block::default()
         .title(title)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme.border))
+        .border_style(theme.border_style())
         .style(Style::default().bg(theme.bg));
 
     if data.is_empty() {
@@ -526,17 +499,17 @@ fn render_mini_chart(
     );
 
     let y_labels = vec![
-        Span::styled(format!("{:.0}", min_y), Style::default().fg(theme.muted)),
-        Span::styled(format!("{:.0}", mid_y), Style::default().fg(theme.muted)),
-        Span::styled(format!("{:.0}", max_y), Style::default().fg(theme.muted)),
+        Span::styled(format!("{:.0}", min_y), theme.muted_style()),
+        Span::styled(format!("{:.0}", mid_y), theme.muted_style()),
+        Span::styled(format!("{:.0}", max_y), theme.muted_style()),
     ];
 
     let x_axis = Axis::default()
-        .style(Style::default().fg(theme.muted))
+        .style(theme.muted_style())
         .bounds([0.0, max_x]);
 
     let y_axis = Axis::default()
-        .style(Style::default().fg(theme.muted))
+        .style(theme.muted_style())
         .bounds([min_y, max_y])
         .labels(y_labels);
 

--- a/cli/src/ui/help.rs
+++ b/cli/src/ui/help.rs
@@ -31,7 +31,7 @@ pub fn render_help(frame: &mut Frame, app: &App, theme: &ThemeColors) {
     let block = Block::default()
         .title(" Help ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme.accent))
+        .border_style(theme.accent_style())
         .style(Style::default().bg(theme.dialog_bg));
 
     let inner = block.inner(area);
@@ -60,7 +60,7 @@ pub fn render_help(frame: &mut Frame, app: &App, theme: &ThemeColors) {
                 app.config.theme_name(),
                 app.config.appearance_label()
             ),
-            Style::default().fg(theme.muted),
+            theme.muted_style(),
         )]),
     ])
     .centered();
@@ -77,7 +77,7 @@ pub fn render_help(frame: &mut Frame, app: &App, theme: &ThemeColors) {
                         .fg(theme.highlight)
                         .add_modifier(Modifier::BOLD),
                 ),
-                Span::styled(binding.description, Style::default().fg(theme.fg)),
+                Span::styled(binding.description, theme.fg_style()),
             ])
         })
         .collect();
@@ -93,38 +93,35 @@ pub fn render_help(frame: &mut Frame, app: &App, theme: &ThemeColors) {
                 .add_modifier(Modifier::BOLD),
         )]),
         Line::from(vec![
-            Span::styled("S      ", Style::default().fg(theme.highlight)),
+            Span::styled("S      ", theme.highlight_style()),
             Span::styled(
                 "Status: R=Run S=Sleep I=Idle T=Stop Z=Zombie",
-                Style::default().fg(theme.fg),
+                theme.fg_style(),
             ),
         ]),
         Line::from(vec![
-            Span::styled("Impact ", Style::default().fg(theme.highlight)),
+            Span::styled("Impact ", theme.highlight_style()),
             Span::styled(
                 "Energy impact score (higher = more drain)",
-                Style::default().fg(theme.fg),
+                theme.fg_style(),
             ),
         ]),
         Line::from(vec![
-            Span::styled("Disk   ", Style::default().fg(theme.highlight)),
-            Span::styled(
-                "Disk I/O since last refresh (read+write)",
-                Style::default().fg(theme.fg),
-            ),
+            Span::styled("Disk   ", theme.highlight_style()),
+            Span::styled("Disk I/O since last refresh (read+write)", theme.fg_style()),
         ]),
         Line::from(vec![
-            Span::styled("Run    ", Style::default().fg(theme.highlight)),
+            Span::styled("Run    ", theme.highlight_style()),
             Span::styled(
                 "Process runtime (how long it's been running)",
-                Style::default().fg(theme.fg),
+                theme.fg_style(),
             ),
         ]),
         Line::from(vec![
-            Span::styled("CPU    ", Style::default().fg(theme.highlight)),
+            Span::styled("CPU    ", theme.highlight_style()),
             Span::styled(
                 "CPU Time: accumulated CPU time consumed by process",
-                Style::default().fg(theme.fg),
+                theme.fg_style(),
             ),
         ]),
     ];
@@ -141,7 +138,7 @@ pub fn render_kill_confirm(frame: &mut Frame, app: &App, theme: &ThemeColors) {
     let block = Block::default()
         .title(" Kill Process? ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme.danger))
+        .border_style(theme.danger_style())
         .style(Style::default().bg(theme.dialog_bg));
 
     let inner = block.inner(area);
@@ -159,11 +156,11 @@ pub fn render_kill_confirm(frame: &mut Frame, app: &App, theme: &ThemeColors) {
                 Style::default()
                     .fg(theme.success)
                     .add_modifier(Modifier::BOLD),
-                Style::default().fg(theme.muted),
+                theme.muted_style(),
                 "Process will be asked to terminate gracefully.",
             ),
             KillSignal::Force => (
-                Style::default().fg(theme.muted),
+                theme.muted_style(),
                 Style::default()
                     .fg(theme.danger)
                     .add_modifier(Modifier::BOLD),
@@ -174,43 +171,31 @@ pub fn render_kill_confirm(frame: &mut Frame, app: &App, theme: &ThemeColors) {
         vec![
             Line::from(""),
             Line::from(vec![
-                Span::styled("Process: ", Style::default().fg(theme.muted)),
-                Span::styled(
-                    &process.name,
-                    Style::default().fg(theme.fg).add_modifier(Modifier::BOLD),
-                ),
+                Span::styled("Process: ", theme.muted_style()),
+                Span::styled(&process.name, theme.fg_style().add_modifier(Modifier::BOLD)),
             ]),
             Line::from(vec![
-                Span::styled("PID: ", Style::default().fg(theme.muted)),
-                Span::styled(process.pid.to_string(), Style::default().fg(theme.fg)),
+                Span::styled("PID: ", theme.muted_style()),
+                Span::styled(process.pid.to_string(), theme.fg_style()),
             ]),
             Line::from(vec![
-                Span::styled("CPU: ", Style::default().fg(theme.muted)),
-                Span::styled(
-                    format!("{:.1}%", process.cpu_usage),
-                    Style::default().fg(theme.fg),
-                ),
+                Span::styled("CPU: ", theme.muted_style()),
+                Span::styled(format!("{:.1}%", process.cpu_usage), theme.fg_style()),
             ]),
             Line::from(vec![
-                Span::styled("Memory: ", Style::default().fg(theme.muted)),
-                Span::styled(
-                    format!("{:.1}MB", process.memory_mb),
-                    Style::default().fg(theme.fg),
-                ),
+                Span::styled("Memory: ", theme.muted_style()),
+                Span::styled(format!("{:.1}MB", process.memory_mb), theme.fg_style()),
             ]),
             Line::from(""),
             Line::from(vec![
-                Span::styled("Signal: ", Style::default().fg(theme.muted)),
+                Span::styled("Signal: ", theme.muted_style()),
                 Span::styled(" Graceful ", graceful_style),
-                Span::styled(" | ", Style::default().fg(theme.muted)),
+                Span::styled(" | ", theme.muted_style()),
                 Span::styled(" Force ", force_style),
-                Span::styled("  [Tab]", Style::default().fg(theme.muted)),
+                Span::styled("  [Tab]", theme.muted_style()),
             ]),
             Line::from(""),
-            Line::from(vec![Span::styled(
-                warning_text,
-                Style::default().fg(theme.warning),
-            )]),
+            Line::from(vec![Span::styled(warning_text, theme.warning_style())]),
             Line::from(""),
             Line::from(vec![
                 Span::styled(
@@ -219,14 +204,14 @@ pub fn render_kill_confirm(frame: &mut Frame, app: &App, theme: &ThemeColors) {
                         .fg(theme.danger)
                         .add_modifier(Modifier::BOLD),
                 ),
-                Span::styled(" Confirm  ", Style::default().fg(theme.fg)),
+                Span::styled(" Confirm  ", theme.fg_style()),
                 Span::styled(
                     "[N]",
                     Style::default()
                         .fg(theme.success)
                         .add_modifier(Modifier::BOLD),
                 ),
-                Span::styled(" Cancel", Style::default().fg(theme.fg)),
+                Span::styled(" Cancel", theme.fg_style()),
             ]),
         ]
     } else {
@@ -246,7 +231,7 @@ pub fn render_about(frame: &mut Frame, _app: &App, theme: &ThemeColors) {
     let block = Block::default()
         .title(" About ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme.accent))
+        .border_style(theme.accent_style())
         .style(Style::default().bg(theme.dialog_bg));
 
     let inner = block.inner(area);
@@ -269,24 +254,24 @@ pub fn render_about(frame: &mut Frame, _app: &App, theme: &ThemeColors) {
         Line::from(""),
         Line::from(vec![Span::styled(
             "A terminal-based battery and energy monitor",
-            Style::default().fg(theme.fg),
+            theme.fg_style(),
         )]),
         Line::from(vec![Span::styled(
             "for macOS Apple Silicon Macs.",
-            Style::default().fg(theme.fg),
+            theme.fg_style(),
         )]),
         Line::from(""),
         Line::from(vec![Span::styled(
             "Track power consumption, battery health,",
-            Style::default().fg(theme.muted),
+            theme.muted_style(),
         )]),
         Line::from(vec![Span::styled(
             "and identify energy-hungry processes.",
-            Style::default().fg(theme.muted),
+            theme.muted_style(),
         )]),
         Line::from(""),
         Line::from(vec![
-            Span::styled("GitHub: ", Style::default().fg(theme.muted)),
+            Span::styled("GitHub: ", theme.muted_style()),
             Span::styled(
                 "https://github.com/jordond/jolt",
                 Style::default()
@@ -297,7 +282,7 @@ pub fn render_about(frame: &mut Frame, _app: &App, theme: &ThemeColors) {
         Line::from(""),
         Line::from(vec![Span::styled(
             "Press 'A' or Esc to close",
-            Style::default().fg(theme.muted),
+            theme.muted_style(),
         )]),
     ];
 

--- a/cli/src/ui/history.rs
+++ b/cli/src/ui/history.rs
@@ -29,7 +29,7 @@ pub fn render(frame: &mut Frame, app: &App, theme: &ThemeColors) {
     let block = Block::default()
         .title(" History ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme.accent))
+        .border_style(theme.accent_style())
         .style(Style::default().bg(theme.dialog_bg));
 
     let inner = block.inner(area);
@@ -76,22 +76,22 @@ fn render_no_daemon(frame: &mut Frame, area: Rect, theme: &ThemeColors) {
         Line::from(""),
         Line::from(vec![Span::styled(
             "Start the daemon to collect history data:",
-            Style::default().fg(theme.muted),
+            theme.muted_style(),
         )]),
         Line::from(""),
         Line::from(vec![Span::styled(
             "  jolt daemon start",
-            Style::default().fg(theme.accent),
+            theme.accent_style(),
         )]),
         Line::from(""),
         Line::from(vec![Span::styled(
             "Or install as a service:",
-            Style::default().fg(theme.muted),
+            theme.muted_style(),
         )]),
         Line::from(""),
         Line::from(vec![Span::styled(
             "  jolt daemon install",
-            Style::default().fg(theme.accent),
+            theme.accent_style(),
         )]),
     ])
     .centered();
@@ -103,7 +103,7 @@ fn render_loading(frame: &mut Frame, area: Rect, theme: &ThemeColors) {
         Line::from(""),
         Line::from(vec![Span::styled(
             "Loading history data...",
-            Style::default().fg(theme.muted),
+            theme.muted_style(),
         )]),
     ])
     .centered();
@@ -128,7 +128,7 @@ fn render_period_tabs(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeCol
                     .bg(theme.accent)
                     .add_modifier(Modifier::BOLD)
             } else {
-                Style::default().fg(theme.muted)
+                theme.muted_style()
             };
             vec![
                 Span::styled(format!(" {} ", p.label()), style),
@@ -146,7 +146,7 @@ fn render_power_chart(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeCol
     let block = Block::default()
         .title(" Power Usage ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme.border));
+        .border_style(theme.border_style());
 
     let inner = block.inner(area);
     frame.render_widget(block, area);
@@ -154,7 +154,7 @@ fn render_power_chart(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeCol
     if app.history_daily_stats.is_empty() && app.history_hourly_stats.is_empty() {
         let no_data = Paragraph::new(vec![Line::from(vec![Span::styled(
             "No data for this period",
-            Style::default().fg(theme.muted),
+            theme.muted_style(),
         )])])
         .centered();
         frame.render_widget(no_data, inner);
@@ -178,7 +178,7 @@ fn render_power_chart(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeCol
     if data_points.is_empty() {
         let no_data = Paragraph::new(vec![Line::from(vec![Span::styled(
             "No data for this period",
-            Style::default().fg(theme.muted),
+            theme.muted_style(),
         )])])
         .centered();
         frame.render_widget(no_data, inner);
@@ -194,7 +194,7 @@ fn render_power_chart(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeCol
     let dataset = Dataset::default()
         .marker(symbols::Marker::Braille)
         .graph_type(GraphType::Line)
-        .style(Style::default().fg(theme.accent))
+        .style(theme.accent_style())
         .data(&data_points);
 
     let x_label = if app.history_period == HistoryPeriod::Today {
@@ -206,14 +206,14 @@ fn render_power_chart(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeCol
     let chart = Chart::new(vec![dataset])
         .x_axis(
             Axis::default()
-                .title(Span::styled(x_label, Style::default().fg(theme.muted)))
-                .style(Style::default().fg(theme.border))
+                .title(Span::styled(x_label, theme.muted_style()))
+                .style(theme.border_style())
                 .bounds([0.0, data_points.len() as f64]),
         )
         .y_axis(
             Axis::default()
-                .title(Span::styled("Watts", Style::default().fg(theme.muted)))
-                .style(Style::default().fg(theme.border))
+                .title(Span::styled("Watts", theme.muted_style()))
+                .style(theme.border_style())
                 .bounds([0.0, max_power * 1.1])
                 .labels(vec![
                     Span::raw("0"),
@@ -285,13 +285,13 @@ fn render_sparklines(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeColo
     let power_block = Block::default()
         .title(" Avg Power (W) ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme.border));
+        .border_style(theme.border_style());
 
     let power_sparkline = Sparkline::default()
         .block(power_block)
         .data(&power_data)
         .max(power_data.iter().copied().max().unwrap_or(100).max(100))
-        .style(Style::default().fg(theme.accent));
+        .style(theme.accent_style());
 
     frame.render_widget(power_sparkline, chunks[0]);
 
@@ -304,13 +304,13 @@ fn render_sparklines(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeColo
     let energy_block = Block::default()
         .title(energy_label)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme.border));
+        .border_style(theme.border_style());
 
     let energy_sparkline = Sparkline::default()
         .block(energy_block)
         .data(&battery_data)
         .max(battery_data.iter().copied().max().unwrap_or(100).max(100))
-        .style(Style::default().fg(theme.success));
+        .style(theme.success_style());
 
     frame.render_widget(energy_sparkline, chunks[1]);
 }
@@ -319,7 +319,7 @@ fn render_summary_stats(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeC
     let block = Block::default()
         .title(" Summary ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme.border));
+        .border_style(theme.border_style());
 
     let inner = block.inner(area);
     frame.render_widget(block, area);
@@ -327,7 +327,7 @@ fn render_summary_stats(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeC
     if app.history_daily_stats.is_empty() {
         let no_data = Paragraph::new(vec![Line::from(vec![Span::styled(
             "No data",
-            Style::default().fg(theme.muted),
+            theme.muted_style(),
         )])])
         .centered();
         frame.render_widget(no_data, inner);
@@ -363,42 +363,30 @@ fn render_summary_stats(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeC
 
     let stats = vec![
         Line::from(vec![
-            Span::styled("Total Energy:  ", Style::default().fg(theme.muted)),
-            Span::styled(
-                format!("{:.1} Wh", total_energy),
-                Style::default().fg(theme.accent),
-            ),
+            Span::styled("Total Energy:  ", theme.muted_style()),
+            Span::styled(format!("{:.1} Wh", total_energy), theme.accent_style()),
         ]),
         Line::from(vec![
-            Span::styled("Avg Power:     ", Style::default().fg(theme.muted)),
-            Span::styled(format!("{:.1} W", avg_power), Style::default().fg(theme.fg)),
+            Span::styled("Avg Power:     ", theme.muted_style()),
+            Span::styled(format!("{:.1} W", avg_power), theme.fg_style()),
         ]),
         Line::from(vec![
-            Span::styled("Max Power:     ", Style::default().fg(theme.muted)),
-            Span::styled(
-                format!("{:.1} W", max_power),
-                Style::default().fg(theme.warning),
-            ),
+            Span::styled("Max Power:     ", theme.muted_style()),
+            Span::styled(format!("{:.1} W", max_power), theme.warning_style()),
         ]),
         Line::from(vec![
-            Span::styled("Screen On:     ", Style::default().fg(theme.muted)),
-            Span::styled(
-                format!("{:.1} hrs", total_screen_hours),
-                Style::default().fg(theme.fg),
-            ),
+            Span::styled("Screen On:     ", theme.muted_style()),
+            Span::styled(format!("{:.1} hrs", total_screen_hours), theme.fg_style()),
         ]),
         Line::from(vec![
-            Span::styled("Charging:      ", Style::default().fg(theme.muted)),
-            Span::styled(
-                format!("{:.1} hrs", total_charging),
-                Style::default().fg(theme.success),
-            ),
+            Span::styled("Charging:      ", theme.muted_style()),
+            Span::styled(format!("{:.1} hrs", total_charging), theme.success_style()),
         ]),
         Line::from(vec![
-            Span::styled("Days:          ", Style::default().fg(theme.muted)),
+            Span::styled("Days:          ", theme.muted_style()),
             Span::styled(
                 format!("{}", app.history_daily_stats.len()),
-                Style::default().fg(theme.fg),
+                theme.fg_style(),
             ),
         ]),
     ];
@@ -418,7 +406,7 @@ fn render_top_processes(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeC
     let block = Block::default()
         .title(" Top Power Consumers ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme.border));
+        .border_style(theme.border_style());
 
     let inner = block.inner(area);
     frame.render_widget(block, area);
@@ -426,7 +414,7 @@ fn render_top_processes(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeC
     if app.history_top_processes.is_empty() {
         let no_data = Paragraph::new(vec![Line::from(vec![Span::styled(
             "No process data",
-            Style::default().fg(theme.muted),
+            theme.muted_style(),
         )])])
         .centered();
         frame.render_widget(no_data, inner);
@@ -507,19 +495,13 @@ fn render_footer(frame: &mut Frame, area: Rect, theme: &ThemeColors) {
     let footer = Paragraph::new(vec![Line::from(vec![
         Span::styled(
             format!("[{}/{}]", keys::PERIOD_PREV, keys::PERIOD_NEXT),
-            Style::default().fg(theme.accent),
+            theme.accent_style(),
         ),
-        Span::styled(" Period  ", Style::default().fg(theme.muted)),
-        Span::styled(
-            format!("[{}]", keys::SETTINGS),
-            Style::default().fg(theme.accent),
-        ),
-        Span::styled(" Settings  ", Style::default().fg(theme.muted)),
-        Span::styled(
-            format!("[{}]", keys::ESC),
-            Style::default().fg(theme.accent),
-        ),
-        Span::styled(" Close", Style::default().fg(theme.muted)),
+        Span::styled(" Period  ", theme.muted_style()),
+        Span::styled(format!("[{}]", keys::SETTINGS), theme.accent_style()),
+        Span::styled(" Settings  ", theme.muted_style()),
+        Span::styled(format!("[{}]", keys::ESC), theme.accent_style()),
+        Span::styled(" Close", theme.muted_style()),
     ])])
     .centered();
     frame.render_widget(footer, area);

--- a/cli/src/ui/power.rs
+++ b/cli/src/ui/power.rs
@@ -13,7 +13,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeColors) {
     let block = Block::default()
         .title(" Power ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme.border))
+        .border_style(theme.border_style())
         .style(Style::default().bg(theme.bg));
 
     let inner = block.inner(area);
@@ -49,7 +49,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeColors) {
     };
 
     let total = Paragraph::new(Line::from(vec![
-        Span::styled("Total: ", Style::default().fg(theme.muted)),
+        Span::styled("Total: ", theme.muted_style()),
         Span::styled(
             total_power,
             Style::default()
@@ -61,13 +61,13 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeColors) {
 
     let cpu = Paragraph::new(Line::from(vec![Span::styled(
         cpu_power,
-        Style::default().fg(theme.accent),
+        theme.accent_style(),
     )]))
     .centered();
 
     let gpu = Paragraph::new(Line::from(vec![Span::styled(
         gpu_power,
-        Style::default().fg(theme.accent_secondary),
+        theme.accent_secondary_style(),
     )]))
     .centered();
 

--- a/cli/src/ui/processes.rs
+++ b/cli/src/ui/processes.rs
@@ -201,9 +201,9 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App, theme: &ThemeColors)
             let killable_style = if is_selected {
                 style
             } else if process.is_killable {
-                Style::default().fg(theme.success)
+                theme.success_style()
             } else {
-                Style::default().fg(theme.muted)
+                theme.muted_style()
             };
 
             let display_name = if *depth > 0 {
@@ -217,10 +217,10 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App, theme: &ThemeColors)
                 style
             } else {
                 match process.status {
-                    ProcessState::Running => Style::default().fg(theme.success),
-                    ProcessState::Sleeping => Style::default().fg(theme.muted),
-                    ProcessState::Idle => Style::default().fg(theme.muted),
-                    _ => Style::default().fg(theme.warning),
+                    ProcessState::Running => theme.success_style(),
+                    ProcessState::Sleeping => theme.muted_style(),
+                    ProcessState::Idle => theme.muted_style(),
+                    _ => theme.warning_style(),
                 }
             };
 

--- a/cli/src/ui/settings.rs
+++ b/cli/src/ui/settings.rs
@@ -34,7 +34,7 @@ pub fn render(frame: &mut Frame, app: &App, theme: &ThemeColors) {
     let block = Block::default()
         .title(" Settings ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme.accent))
+        .border_style(theme.accent_style())
         .style(Style::default().bg(theme.dialog_bg));
 
     let inner = block.inner(area);
@@ -88,30 +88,27 @@ fn render_status_section(frame: &mut Frame, area: Rect, app: &App, theme: &Theme
 
         vec![
             Line::from(vec![
-                Span::styled("Background: ", Style::default().fg(theme.muted)),
+                Span::styled("Background: ", theme.muted_style()),
                 Span::styled(
                     bg_status,
                     Style::default().fg(bg_color).add_modifier(Modifier::BOLD),
                 ),
                 Span::raw(bg_spacer),
-                Span::styled("Uptime: ", Style::default().fg(theme.muted)),
-                Span::styled(uptime_str, Style::default().fg(theme.fg)),
+                Span::styled("Uptime: ", theme.muted_style()),
+                Span::styled(uptime_str, theme.fg_style()),
             ]),
             Line::from(vec![
-                Span::styled("Samples: ", Style::default().fg(theme.muted)),
-                Span::styled(
-                    format!("{:<8}", status.sample_count),
-                    Style::default().fg(theme.accent),
-                ),
+                Span::styled("Samples: ", theme.muted_style()),
+                Span::styled(format!("{:<8}", status.sample_count), theme.accent_style()),
                 Span::raw(samples_spacer),
-                Span::styled("DB Size: ", Style::default().fg(theme.muted)),
-                Span::styled(size_str, Style::default().fg(theme.fg)),
+                Span::styled("DB Size: ", theme.muted_style()),
+                Span::styled(size_str, theme.fg_style()),
             ]),
         ]
     } else {
         vec![
             Line::from(vec![
-                Span::styled("Background: ", Style::default().fg(theme.muted)),
+                Span::styled("Background: ", theme.muted_style()),
                 Span::styled(
                     bg_status,
                     Style::default().fg(bg_color).add_modifier(Modifier::BOLD),
@@ -119,7 +116,7 @@ fn render_status_section(frame: &mut Frame, area: Rect, app: &App, theme: &Theme
             ]),
             Line::from(vec![Span::styled(
                 "No daemon connection",
-                Style::default().fg(theme.muted),
+                theme.muted_style(),
             )]),
         ]
     };
@@ -131,7 +128,7 @@ fn render_status_section(frame: &mut Frame, area: Rect, app: &App, theme: &Theme
 fn render_divider(frame: &mut Frame, area: Rect, theme: &ThemeColors) {
     let divider = Paragraph::new(Line::from(vec![Span::styled(
         "\u{2500}".repeat(area.width as usize),
-        Style::default().fg(theme.border),
+        theme.border_style(),
     )]));
     frame.render_widget(divider, area);
 }
@@ -157,13 +154,13 @@ fn render_items_section(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeC
                         .bg(theme.selection_bg)
                         .add_modifier(Modifier::BOLD)
                 } else {
-                    Style::default().fg(theme.fg)
+                    theme.fg_style()
                 };
 
                 let value_style = if is_selected {
                     style.fg(theme.accent)
                 } else {
-                    Style::default().fg(theme.accent)
+                    theme.accent_style()
                 };
 
                 Line::from(vec![
@@ -181,11 +178,8 @@ fn render_items_section(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeC
 
 fn render_footer(frame: &mut Frame, area: Rect, theme: &ThemeColors) {
     let footer = Paragraph::new(Line::from(vec![
-        Span::styled(
-            format!("[{}]", keys::ESC),
-            Style::default().fg(theme.accent),
-        ),
-        Span::styled(" Close", Style::default().fg(theme.muted)),
+        Span::styled(format!("[{}]", keys::ESC), theme.accent_style()),
+        Span::styled(" Close", theme.muted_style()),
     ]))
     .alignment(Alignment::Center);
     frame.render_widget(footer, area);

--- a/cli/src/ui/status_bar.rs
+++ b/cli/src/ui/status_bar.rs
@@ -20,8 +20,8 @@ pub fn render_title_bar(
     let version = super::VERSION;
 
     let left_spans = vec![
-        Span::styled("⚡️jolt ", Style::default().fg(theme.accent)),
-        Span::styled(format!("v{}", version), Style::default().fg(theme.muted)),
+        Span::styled("⚡️jolt ", theme.accent_style()),
+        Span::styled(format!("v{}", version), theme.muted_style()),
     ];
 
     let right_text = format!(
@@ -37,7 +37,7 @@ pub fn render_title_bar(
 
     let mut spans = left_spans;
     spans.push(Span::raw(" ".repeat(padding)));
-    spans.push(Span::styled(right_text, Style::default().fg(theme.muted)));
+    spans.push(Span::styled(right_text, theme.muted_style()));
 
     let bar = Paragraph::new(Line::from(spans)).style(Style::default().bg(theme.bg));
     frame.render_widget(bar, area);
@@ -66,13 +66,10 @@ pub fn render_status_bar(frame: &mut Frame, area: Rect, app: &App, theme: &Theme
     let mut left_spans: Vec<Span> = vec![Span::raw(" ")];
     for (i, (key, desc)) in left_hints.iter().enumerate() {
         if i > 0 {
-            left_spans.push(Span::styled(" │ ", Style::default().fg(theme.border)));
+            left_spans.push(Span::styled(" │ ", theme.border_style()));
         }
-        left_spans.push(Span::styled(*key, Style::default().fg(theme.accent)));
-        left_spans.push(Span::styled(
-            format!(" {}", desc),
-            Style::default().fg(theme.muted),
-        ));
+        left_spans.push(Span::styled(*key, theme.accent_style()));
+        left_spans.push(Span::styled(format!(" {}", desc), theme.muted_style()));
     }
 
     let background_recording = app.config.user_config.history.background_recording;
@@ -80,21 +77,18 @@ pub fn render_status_bar(frame: &mut Frame, area: Rect, app: &App, theme: &Theme
     let mut right_spans: Vec<Span> = Vec::new();
 
     if app.is_reconnecting() {
-        right_spans.push(Span::styled(
-            "⟳ reconnecting ",
-            Style::default().fg(theme.warning),
-        ));
-        right_spans.push(Span::styled("│ ", Style::default().fg(theme.border)));
+        right_spans.push(Span::styled("⟳ reconnecting ", theme.warning_style()));
+        right_spans.push(Span::styled("│ ", theme.border_style()));
     } else if app.is_data_stale() {
-        right_spans.push(Span::styled("⚠ stale ", Style::default().fg(theme.warning)));
-        right_spans.push(Span::styled("│ ", Style::default().fg(theme.border)));
+        right_spans.push(Span::styled("⚠ stale ", theme.warning_style()));
+        right_spans.push(Span::styled("│ ", theme.border_style()));
     }
 
     if background_recording {
         right_spans.extend(vec![
-            Span::styled("background: ", Style::default().fg(theme.muted)),
-            Span::styled("on", Style::default().fg(theme.success)),
-            Span::styled(" │ ", Style::default().fg(theme.border)),
+            Span::styled("background: ", theme.muted_style()),
+            Span::styled("on", theme.success_style()),
+            Span::styled(" │ ", theme.border_style()),
         ]);
     }
 
@@ -104,16 +98,16 @@ pub fn render_status_bar(frame: &mut Frame, area: Rect, app: &App, theme: &Theme
         format!("{}ms", app.refresh_ms)
     };
     right_spans.extend(vec![
-        Span::styled("refresh: ", Style::default().fg(theme.muted)),
-        Span::styled(refresh_display, Style::default().fg(theme.fg)),
-        Span::styled(" │ ", Style::default().fg(theme.border)),
+        Span::styled("refresh: ", theme.muted_style()),
+        Span::styled(refresh_display, theme.fg_style()),
+        Span::styled(" │ ", theme.border_style()),
     ]);
 
     right_spans.extend(vec![
-        Span::styled(keys::HISTORY, Style::default().fg(theme.accent)),
-        Span::styled(" history ", Style::default().fg(theme.muted)),
-        Span::styled(keys::SETTINGS, Style::default().fg(theme.accent)),
-        Span::styled(" settings ", Style::default().fg(theme.muted)),
+        Span::styled(keys::HISTORY, theme.accent_style()),
+        Span::styled(" history ", theme.muted_style()),
+        Span::styled(keys::SETTINGS, theme.accent_style()),
+        Span::styled(" settings ", theme.muted_style()),
     ]);
 
     let left_width: usize = left_spans.iter().map(|s| s.width()).sum();

--- a/cli/src/ui/system_stats.rs
+++ b/cli/src/ui/system_stats.rs
@@ -13,7 +13,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeColors) {
     let block = Block::default()
         .title(" System ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme.border))
+        .border_style(theme.border_style())
         .style(Style::default().bg(theme.bg));
 
     let inner = block.inner(area);
@@ -91,7 +91,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeColors) {
     };
 
     let cpu = Paragraph::new(Line::from(vec![
-        Span::styled("CPU: ", Style::default().fg(theme.muted)),
+        Span::styled("CPU: ", theme.muted_style()),
         Span::styled(
             cpu_text,
             Style::default().fg(cpu_color).add_modifier(Modifier::BOLD),
@@ -100,7 +100,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeColors) {
     .centered();
 
     let load = Paragraph::new(Line::from(vec![
-        Span::styled("Load: ", Style::default().fg(theme.muted)),
+        Span::styled("Load: ", theme.muted_style()),
         Span::styled(
             load_text,
             Style::default().fg(load_color).add_modifier(Modifier::BOLD),
@@ -109,7 +109,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeColors) {
     .centered();
 
     let memory = Paragraph::new(Line::from(vec![
-        Span::styled("Mem: ", Style::default().fg(theme.muted)),
+        Span::styled("Mem: ", theme.muted_style()),
         Span::styled(
             memory_text,
             Style::default()
@@ -120,11 +120,8 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeColors) {
     .centered();
 
     let uptime = Paragraph::new(Line::from(vec![
-        Span::styled("Uptime: ", Style::default().fg(theme.muted)),
-        Span::styled(
-            uptime_text,
-            Style::default().fg(theme.fg).add_modifier(Modifier::BOLD),
-        ),
+        Span::styled("Uptime: ", theme.muted_style()),
+        Span::styled(uptime_text, theme.fg_style().add_modifier(Modifier::BOLD)),
     ]))
     .centered();
 

--- a/cli/src/ui/theme_importer.rs
+++ b/cli/src/ui/theme_importer.rs
@@ -30,7 +30,7 @@ pub fn render(frame: &mut Frame, app: &App, theme: &ThemeColors) {
     let block = Block::default()
         .title(status)
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme.accent))
+        .border_style(theme.accent_style())
         .style(Style::default().bg(theme.dialog_bg));
 
     let inner = block.inner(area);
@@ -65,15 +65,15 @@ fn render_search_bar(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeColo
     };
 
     let style = if app.importer_filter.is_empty() && !is_focused {
-        Style::default().fg(theme.muted)
+        theme.muted_style()
     } else {
-        Style::default().fg(theme.fg)
+        theme.fg_style()
     };
 
     let border_style = if is_focused {
-        Style::default().fg(theme.accent)
+        theme.accent_style()
     } else {
-        Style::default().fg(theme.border)
+        theme.border_style()
     };
 
     let title = if is_focused {
@@ -130,27 +130,27 @@ fn render_theme_list(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeColo
                     .bg(theme.selection_bg)
                     .add_modifier(Modifier::BOLD)
             } else if is_checked {
-                Style::default().fg(theme.accent)
+                theme.accent_style()
             } else {
-                Style::default().fg(theme.fg)
+                theme.fg_style()
             };
 
             let checkbox_style = if is_selected {
                 style
             } else if is_checked {
-                Style::default().fg(theme.success)
+                theme.success_style()
             } else {
-                Style::default().fg(theme.muted)
+                theme.muted_style()
             };
 
             let variant_style = if is_selected {
                 style
             } else {
                 match (&group.dark, &group.light) {
-                    (Some(_), Some(_)) => Style::default().fg(theme.accent),
-                    (Some(_), None) => Style::default().fg(theme.muted),
-                    (None, Some(_)) => Style::default().fg(theme.highlight),
-                    _ => Style::default().fg(theme.muted),
+                    (Some(_), Some(_)) => theme.accent_style(),
+                    (Some(_), None) => theme.muted_style(),
+                    (None, Some(_)) => theme.highlight_style(),
+                    _ => theme.muted_style(),
                 }
             };
 
@@ -166,7 +166,7 @@ fn render_theme_list(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeColo
     let list_block = Block::default()
         .title(format!(" {} themes ", groups.len()))
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme.border));
+        .border_style(theme.border_style());
 
     let list_inner = list_block.inner(area);
     frame.render_widget(list_block, area);
@@ -208,21 +208,18 @@ fn render_footer(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeColors) 
     };
 
     let footer = Paragraph::new(vec![
-        Line::from(vec![Span::styled(
-            &left_text,
-            Style::default().fg(theme.muted),
-        )]),
+        Line::from(vec![Span::styled(&left_text, theme.muted_style())]),
         Line::from(vec![
-            Span::styled("/", Style::default().fg(theme.accent)),
-            Span::styled(" search  ", Style::default().fg(theme.muted)),
-            Span::styled("Space", Style::default().fg(theme.accent)),
-            Span::styled(" select  ", Style::default().fg(theme.muted)),
-            Span::styled("p", Style::default().fg(theme.accent)),
-            Span::styled(" preview  ", Style::default().fg(theme.muted)),
-            Span::styled("i", Style::default().fg(theme.accent)),
-            Span::styled(" import  ", Style::default().fg(theme.muted)),
-            Span::styled("r", Style::default().fg(theme.accent)),
-            Span::styled(" refresh", Style::default().fg(theme.muted)),
+            Span::styled("/", theme.accent_style()),
+            Span::styled(" search  ", theme.muted_style()),
+            Span::styled("Space", theme.accent_style()),
+            Span::styled(" select  ", theme.muted_style()),
+            Span::styled("p", theme.accent_style()),
+            Span::styled(" preview  ", theme.muted_style()),
+            Span::styled("i", theme.accent_style()),
+            Span::styled(" import  ", theme.muted_style()),
+            Span::styled("r", theme.accent_style()),
+            Span::styled(" refresh", theme.muted_style()),
         ]),
     ]);
 

--- a/cli/src/ui/theme_picker.rs
+++ b/cli/src/ui/theme_picker.rs
@@ -30,7 +30,7 @@ pub fn render(frame: &mut Frame, app: &App, theme: &ThemeColors) {
     let block = Block::default()
         .title(" Select Theme ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme.accent))
+        .border_style(theme.accent_style())
         .style(Style::default().bg(theme.dialog_bg));
 
     let inner = block.inner(area);
@@ -48,7 +48,7 @@ pub fn render(frame: &mut Frame, app: &App, theme: &ThemeColors) {
 
     let header = Paragraph::new(Line::from(vec![Span::styled(
         "↑↓ navigate  Enter select  Esc cancel",
-        Style::default().fg(theme.muted),
+        theme.muted_style(),
     )]))
     .centered();
     frame.render_widget(header, chunks[0]);
@@ -79,13 +79,13 @@ pub fn render(frame: &mut Frame, app: &App, theme: &ThemeColors) {
                     .bg(theme.selection_bg)
                     .add_modifier(Modifier::BOLD)
             } else {
-                Style::default().fg(theme.fg)
+                theme.fg_style()
             };
 
             let name_style = if is_selected {
                 style
             } else if !theme_item.is_builtin {
-                Style::default().fg(theme.accent_secondary)
+                theme.accent_secondary_style()
             } else {
                 style
             };
@@ -96,7 +96,7 @@ pub fn render(frame: &mut Frame, app: &App, theme: &ThemeColors) {
                     if is_selected {
                         style
                     } else {
-                        Style::default().fg(theme.accent)
+                        theme.accent_style()
                     },
                 ),
                 Span::styled(&theme_item.name, name_style),
@@ -120,17 +120,17 @@ pub fn render(frame: &mut Frame, app: &App, theme: &ThemeColors) {
 
     let footer = Paragraph::new(vec![
         Line::from(vec![
-            Span::styled("Preview: ", Style::default().fg(theme.muted)),
-            Span::styled(preview_mode, Style::default().fg(theme.accent)),
-            Span::styled("  Variants: ", Style::default().fg(theme.muted)),
-            Span::styled(variants_info, Style::default().fg(theme.accent)),
+            Span::styled("Preview: ", theme.muted_style()),
+            Span::styled(preview_mode, theme.accent_style()),
+            Span::styled("  Variants: ", theme.muted_style()),
+            Span::styled(variants_info, theme.accent_style()),
         ]),
         Line::default(),
         Line::from(vec![
-            Span::styled("a/←→", Style::default().fg(theme.accent)),
-            Span::styled(" toggle preview  ", Style::default().fg(theme.muted)),
-            Span::styled("i", Style::default().fg(theme.accent)),
-            Span::styled(" import themes", Style::default().fg(theme.muted)),
+            Span::styled("a/←→", theme.accent_style()),
+            Span::styled(" toggle preview  ", theme.muted_style()),
+            Span::styled("i", theme.accent_style()),
+            Span::styled(" import themes", theme.muted_style()),
         ]),
     ])
     .centered();


### PR DESCRIPTION
## Summary

- Add helper methods to `ThemeColors` for common style patterns (`muted_style()`, `accent_style()`, etc.)
- Replace ~258 verbose `Style::default().fg(theme.xxx)` patterns with concise `theme.xxx_style()` calls
- Pure refactoring for readability - no functional changes

## Changes

### New Style Helpers (`cli/src/theme/mod.rs`)
```rust
impl ThemeColors {
    pub fn fg_style(&self) -> Style
    pub fn muted_style(&self) -> Style
    pub fn accent_style(&self) -> Style
    pub fn accent_secondary_style(&self) -> Style
    pub fn highlight_style(&self) -> Style
    pub fn success_style(&self) -> Style
    pub fn warning_style(&self) -> Style
    pub fn danger_style(&self) -> Style
    pub fn border_style(&self) -> Style
    pub fn graph_style(&self) -> Style
}
```

### Before/After Example
```rust
// Before
Span::styled("Label: ", Style::default().fg(theme.muted))

// After
Span::styled("Label: ", theme.muted_style())
```

### Files Modified
- `cli/src/theme/mod.rs` - Added 11 style helper methods
- `cli/src/ui/graphs.rs` - ~55 replacements
- `cli/src/ui/history.rs` - ~50 replacements
- `cli/src/ui/battery.rs` - ~45 replacements
- `cli/src/ui/help.rs` - ~35 replacements
- `cli/src/ui/battery_details.rs` - ~30 replacements
- 8 other UI files

## Verification

- ✅ `cargo clippy` - No warnings
- ✅ `cargo test` - 78 tests pass
- ✅ `cargo build --release` - Success
- ✅ `./scripts/check` - All checks pass

## Stats

```
14 files changed, 362 insertions(+), 394 deletions(-)
```

Net reduction of 32 lines while improving code readability.