### PR TITLE
fix(cargo): only compile mac os deps when compiling on macos

### DIFF
--- a/crates/platform/Cargo.toml
+++ b/crates/platform/Cargo.toml
@@ -22,6 +22,7 @@ color-eyre = { workspace = true }
 sysinfo = { workspace = true }
 
 # macOS-specific (optional)
+[target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = { workspace = true, optional = true }
 core-foundation-sys = { workspace = true, optional = true }
 mach2 = { workspace = true, optional = true }


### PR DESCRIPTION
this is a simpler human made version of #118 that doesn't make as much of changes but it works, although I would prefer #118 because it seems to fix the issue from its roots (i don't have macos to be sure) this can treated as _a temporally solution_