### PR TITLE
fix(ci): update workflows for automatic platform detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
           workspaces: cli
           key: ${{ matrix.target }}
       - name: Build
-        run: ${{ matrix.use-cross && 'cross' || 'cargo' }} build --release --target ${{ matrix.target }}
+        run: ${{ matrix.use-cross && 'cross' || 'cargo' }} build --release --target ${{ matrix.target }} -p jolt-tui
 
   website-lint:
     name: Website Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           key: ${{ matrix.target }}
 
       - name: Build binary
-        run: ${{ matrix.use-cross && 'cross' || 'cargo' }} build --release --target ${{ matrix.target }}
+        run: ${{ matrix.use-cross && 'cross' || 'cargo' }} build --release --target ${{ matrix.target }} -p jolt-tui
 
       - name: Prepare release artifacts
         run: |


### PR DESCRIPTION
Fixes CI/release after #118 removed platform feature flags.

- Remove `--features macos/linux` from release builds (no longer needed)
- Simplify to use `cross` for all targets
- Add all 6 release targets to CI matrix