### PR TITLE
fix: gauge panic without a battery, and stale Cargo.lock in releases

### DIFF
--- a/.github/versions.sh
+++ b/.github/versions.sh
@@ -14,6 +14,33 @@ fi
 
 VERSION="${VERSION#v}"
 
+# Re-resolve Cargo.lock so it pins the versions just written to Cargo.toml.
+# Without this the lock file keeps the previous versions and tagged releases
+# ship a stale lock (see issue #159).
+#
+# Never fails the script: this also runs in jobs that only need the manifest
+# rewritten, and a missing cargo or an unreachable registry must not break them.
+update_lockfile() {
+	if ! command -v cargo >/dev/null 2>&1; then
+		echo "cargo not found, leaving Cargo.lock untouched" >&2
+		return 0
+	fi
+
+	# --workspace re-resolves only the local crates, so third-party
+	# dependencies keep the versions already pinned in the lock file.
+	# Offline first: re-resolving path dependencies needs no registry lookup.
+	if cargo update --workspace --offline --quiet; then
+		return 0
+	fi
+
+	echo "Offline Cargo.lock update failed, retrying with network access" >&2
+	if ! cargo update --workspace --quiet; then
+		echo "Warning: could not update Cargo.lock" >&2
+	fi
+
+	return 0
+}
+
 echo "Updating version to ${VERSION}"
 
 sed -i.bak 's/^version = ".*"/version = "'"${VERSION}"'"/' Cargo.toml
@@ -22,5 +49,8 @@ sed -i.bak 's/\(jolt-theme = { path = "crates\/theme", version = "\)[^"]*"/\1'"$
 sed -i.bak 's/\(jolt-platform = { path = "crates\/platform", version = "\)[^"]*"/\1'"${VERSION}"'"/' Cargo.toml
 rm -f Cargo.toml.bak
 
+update_lockfile
+
 echo "Updated versions:"
 grep -E '^version|jolt-(protocol|theme|platform)' Cargo.toml
+grep -A1 '^name = "jolt-tui"' Cargo.lock || echo "jolt-tui not found in Cargo.lock" >&2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,7 +196,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Cargo.toml
+          git add Cargo.toml Cargo.lock
           if git diff --staged --quiet; then
             echo "committed=false" >> $GITHUB_OUTPUT
           else

--- a/cli/src/ui/battery.rs
+++ b/cli/src/ui/battery.rs
@@ -11,7 +11,9 @@ use crate::data::battery::ChargeState;
 use crate::data::power::PowerMode;
 use crate::theme::ThemeColors;
 
-use super::utils::{color_for_percent, format_energy_ratio, format_temperature};
+use super::utils::{
+    color_for_percent, format_energy_ratio, format_percent, format_temperature, sanitize_percent,
+};
 
 /// Returns the icon for the given power mode.
 fn power_mode_icon(mode: PowerMode) -> &'static str {
@@ -72,10 +74,14 @@ fn render_battery_gauge(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeC
     let gauge_color = color_for_percent(percent, 50.0, 20.0, theme);
     let unfilled_color = darken_color(theme.border, 0.6);
 
+    // `Gauge` panics unless the ratio is within 0..=1, and `f32::clamp`
+    // propagates NaN, so the reading has to be sanitized before it gets here.
+    let ratio = f64::from(sanitize_percent(percent)) / 100.0;
+
     let gauge = Gauge::default()
         .gauge_style(Style::default().fg(gauge_color).bg(unfilled_color))
-        .ratio((percent / 100.0).clamp(0.0, 1.0) as f64)
-        .label(format!("{:.0}%", percent))
+        .ratio(ratio)
+        .label(format_percent(percent, 0))
         .use_unicode(true);
 
     frame.render_widget(gauge, area);
@@ -226,7 +232,7 @@ fn render_battery_info_card(
     let mut right_spans = vec![
         Span::styled("Health: ", theme.muted_style()),
         Span::styled(
-            format!("{:.0}%", app.battery.health_percent()),
+            format_percent(app.battery.health_percent(), 0),
             Style::default()
                 .fg(health_color)
                 .add_modifier(Modifier::BOLD),

--- a/cli/src/ui/battery_details.rs
+++ b/cli/src/ui/battery_details.rs
@@ -12,11 +12,13 @@ use crate::theme::ThemeColors;
 
 use super::utils::{
     centered_rect, color_for_percent, color_for_value, convert_temperature, format_energy,
-    format_temperature, format_temperature_short,
+    format_percent, format_temperature, format_temperature_short, sanitize_percent,
 };
 
 fn text_gauge(percent: f32, width: usize, color: Color) -> Span<'static> {
-    let filled = ((percent / 100.0) * width as f32) as usize;
+    // Sanitize first: a NaN or out-of-range reading would otherwise render a
+    // bar that is empty or wider than `width`.
+    let filled = ((sanitize_percent(percent) / 100.0) * width as f32) as usize;
     let empty = width.saturating_sub(filled);
     let gauge_str = format!("{}{}", "█".repeat(filled), "░".repeat(empty));
     Span::styled(gauge_str, Style::default().fg(color))
@@ -108,7 +110,7 @@ fn render_charge_info(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeCol
         Line::from(vec![
             Span::styled("Charge:     ", theme.muted_style()),
             Span::styled(
-                format!("{:.1}%", percent),
+                format_percent(percent, 1),
                 Style::default()
                     .fg(percent_color)
                     .add_modifier(Modifier::BOLD),
@@ -152,7 +154,7 @@ fn render_health_info(frame: &mut Frame, area: Rect, app: &App, theme: &ThemeCol
         Line::from(vec![
             Span::styled("Health:     ", theme.muted_style()),
             Span::styled(
-                format!("{:.1}%", health),
+                format_percent(health, 1),
                 Style::default()
                     .fg(health_color)
                     .add_modifier(Modifier::BOLD),

--- a/cli/src/ui/utils.rs
+++ b/cli/src/ui/utils.rs
@@ -26,8 +26,38 @@ pub fn centered_rect_percent(area: Rect, width_percent: u16, height_percent: u16
     Rect::new(x, y, width, height)
 }
 
+/// Clamp a percentage into the 0-100 range, mapping non-finite values to 0.
+///
+/// Some power sources report a zero maximum capacity, which makes the
+/// underlying `energy / energy_full` division produce NaN. `f32::clamp`
+/// propagates NaN, so any widget that asserts on its input (such as
+/// `Gauge::ratio`) must be fed through this first.
+pub fn sanitize_percent(percent: f32) -> f32 {
+    if percent.is_finite() {
+        percent.clamp(0.0, 100.0)
+    } else {
+        0.0
+    }
+}
+
+/// Format a percentage with the given precision, or "—" when it is not finite.
+///
+/// Unlike [`sanitize_percent`] the value is not clamped: a battery legitimately
+/// reporting above 100% health should still be shown as-is.
+pub fn format_percent(percent: f32, precision: usize) -> String {
+    if percent.is_finite() {
+        format!("{:.*}%", precision, percent)
+    } else {
+        "—".to_string()
+    }
+}
+
 /// Returns success/warning/danger color based on percent vs thresholds (higher is better).
+///
+/// Non-finite percentages are treated as 0 so a broken reading renders as
+/// `danger` instead of relying on NaN comparison semantics.
 pub fn color_for_percent(percent: f32, high: f32, low: f32, theme: &ThemeColors) -> Color {
+    let percent = sanitize_percent(percent);
     if percent > high {
         theme.success
     } else if percent > low {
@@ -141,6 +171,99 @@ pub fn truncate_str(s: &str, max_len: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn theme() -> ThemeColors {
+        ThemeColors::from(jolt_theme::ThemeColors::default())
+    }
+
+    // Percent sanitization tests (guards against panicking gauge widgets)
+    #[test]
+    fn test_sanitize_percent_passes_through_valid_values() {
+        assert_eq!(sanitize_percent(0.0), 0.0);
+        assert_eq!(sanitize_percent(42.5), 42.5);
+        assert_eq!(sanitize_percent(100.0), 100.0);
+    }
+
+    #[test]
+    fn test_sanitize_percent_maps_non_finite_to_zero() {
+        // Reported by machines with no real battery: 0.0 / 0.0 energy ratio.
+        assert_eq!(sanitize_percent(f32::NAN), 0.0);
+        assert_eq!(sanitize_percent(f32::INFINITY), 0.0);
+        assert_eq!(sanitize_percent(f32::NEG_INFINITY), 0.0);
+    }
+
+    #[test]
+    fn test_sanitize_percent_clamps_out_of_range() {
+        assert_eq!(sanitize_percent(-1.0), 0.0);
+        assert_eq!(sanitize_percent(-500.0), 0.0);
+        assert_eq!(sanitize_percent(101.0), 100.0);
+        assert_eq!(sanitize_percent(500.0), 100.0);
+    }
+
+    #[test]
+    fn test_sanitize_percent_always_yields_a_valid_gauge_ratio() {
+        for percent in [
+            f32::NAN,
+            f32::INFINITY,
+            f32::NEG_INFINITY,
+            -500.0,
+            -0.1,
+            0.0,
+            50.0,
+            100.0,
+            100.1,
+            500.0,
+        ] {
+            let ratio = f64::from(sanitize_percent(percent)) / 100.0;
+            assert!(
+                (0.0..=1.0).contains(&ratio),
+                "ratio {ratio} out of range for percent {percent}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_format_percent_renders_finite_values() {
+        assert_eq!(format_percent(0.0, 0), "0%");
+        assert_eq!(format_percent(42.4, 0), "42%");
+        assert_eq!(format_percent(42.45, 1), "42.5%");
+        // Health above 100% is a real reading and must not be clamped away.
+        assert_eq!(format_percent(101.0, 0), "101%");
+    }
+
+    #[test]
+    fn test_format_percent_renders_non_finite_as_dash() {
+        assert_eq!(format_percent(f32::NAN, 0), "—");
+        assert_eq!(format_percent(f32::INFINITY, 1), "—");
+        assert_eq!(format_percent(f32::NEG_INFINITY, 0), "—");
+    }
+
+    #[test]
+    fn test_color_for_percent_treats_non_finite_as_danger() {
+        let theme = theme();
+        assert_eq!(
+            color_for_percent(f32::NAN, 50.0, 20.0, &theme),
+            theme.danger
+        );
+        assert_eq!(
+            color_for_percent(f32::NEG_INFINITY, 50.0, 20.0, &theme),
+            theme.danger
+        );
+        assert_eq!(
+            color_for_percent(f32::INFINITY, 50.0, 20.0, &theme),
+            theme.danger
+        );
+    }
+
+    #[test]
+    fn test_color_for_percent_thresholds() {
+        let theme = theme();
+        assert_eq!(color_for_percent(80.0, 50.0, 20.0, &theme), theme.success);
+        assert_eq!(color_for_percent(30.0, 50.0, 20.0, &theme), theme.warning);
+        assert_eq!(color_for_percent(10.0, 50.0, 20.0, &theme), theme.danger);
+        // Out-of-range highs clamp down to 100 and stay in the success band.
+        assert_eq!(color_for_percent(500.0, 50.0, 20.0, &theme), theme.success);
+    }
 
     // Energy conversion tests (Wh to mAh using 11.4V nominal)
     #[test]

--- a/crates/platform/src/battery.rs
+++ b/crates/platform/src/battery.rs
@@ -154,16 +154,84 @@ pub trait BatteryProvider {
     }
 
     /// Check if a battery is available on this system.
+    ///
+    /// A power source only counts as a battery when its readings are usable.
+    /// Machines with no real battery (desktop Macs, pseudo power sources) can
+    /// still expose a power source whose maximum capacity is zero, which makes
+    /// the `energy / energy_full` state-of-charge division produce NaN. Those
+    /// are reported as "no battery" so callers take their existing no-battery
+    /// path instead of rendering a degraded UI.
     fn is_available() -> bool
     where
         Self: Sized,
     {
+        use starship_battery::units::energy::watt_hour;
+        use starship_battery::units::ratio::percent;
         use starship_battery::Manager;
+
         Manager::new()
             .ok()
             .and_then(|m| m.batteries().ok())
             .and_then(|mut b| b.next())
             .and_then(|b| b.ok())
-            .is_some()
+            .is_some_and(|battery| {
+                has_usable_readings(
+                    battery.state_of_charge().get::<percent>(),
+                    battery.energy_full().get::<watt_hour>(),
+                )
+            })
+    }
+}
+
+/// Whether a power source's readings describe a battery jolt can display.
+///
+/// A charge percentage is only meaningful when it is finite and non-negative.
+/// A maximum capacity of zero (or a non-finite one) means the source is not a
+/// real battery, and it is also what makes `state_of_charge()` return NaN,
+/// which downstream gauge widgets refuse to render.
+fn has_usable_readings(charge_percent: f32, max_capacity_wh: f32) -> bool {
+    charge_percent.is_finite()
+        && charge_percent >= 0.0
+        && max_capacity_wh.is_finite()
+        && max_capacity_wh > 0.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::has_usable_readings;
+
+    #[test]
+    fn accepts_a_real_battery() {
+        assert!(has_usable_readings(0.0, 52.6));
+        assert!(has_usable_readings(63.5, 52.6));
+        assert!(has_usable_readings(100.0, 52.6));
+    }
+
+    #[test]
+    fn rejects_non_finite_charge_percent() {
+        // 0.0 / 0.0 on a machine whose power source reports no capacity.
+        assert!(!has_usable_readings(f32::NAN, 52.6));
+        assert!(!has_usable_readings(f32::INFINITY, 52.6));
+        assert!(!has_usable_readings(f32::NEG_INFINITY, 52.6));
+    }
+
+    #[test]
+    fn rejects_out_of_range_charge_percent() {
+        assert!(!has_usable_readings(-0.1, 52.6));
+        assert!(!has_usable_readings(-100.0, 52.6));
+    }
+
+    #[test]
+    fn rejects_unusable_max_capacity() {
+        assert!(!has_usable_readings(63.5, 0.0));
+        assert!(!has_usable_readings(63.5, -1.0));
+        assert!(!has_usable_readings(63.5, f32::NAN));
+        assert!(!has_usable_readings(63.5, f32::INFINITY));
+    }
+
+    #[test]
+    fn rejects_a_pseudo_power_source() {
+        // Desktop Macs: zero energy and zero max capacity, so the ratio is NaN.
+        assert!(!has_usable_readings(f32::NAN, 0.0));
     }
 }

--- a/scripts/check
+++ b/scripts/check
@@ -54,7 +54,7 @@ fi
 
 if [ "$1" = "--test" ] || [ "$1" = "-t" ]; then
     print_step "Running tests..."
-    if cargo test; then
+    if cargo test --workspace; then
         print_success "Tests OK"
     else
         print_error "Tests failed"


### PR DESCRIPTION
Two unrelated small fixes.

## Fixes #114: panic on machines without a usable battery

`Gauge::ratio` asserts its input is within `0..=1`. The existing `.clamp(0.0, 1.0)` doesn't guard it, because `f32::clamp` propagates NaN. On a desktop Mac the power source reports zero max capacity, so `starship-battery`'s `state_of_charge()` divides `0.0 / 0.0` and hands us NaN. Straight to a panic on startup.

- New `sanitize_percent()` and `format_percent()` in `ui/utils.rs`. Sanitize maps non-finite to 0 and clamps to 0-100; format renders `—` for non-finite values and deliberately does not clamp, since health above 100% is a real reading.
- `battery.rs` and `battery_details.rs` route charge and health percentages through them. `text_gauge()` had the same problem in a quieter form: NaN drew an empty bar and values above 100 drew past `width`.
- `BatteryProvider::is_available()` now checks that a power source's readings are usable, not just that it exists. Machines like this one fall into the existing `require_battery()` path and get the "No battery found" message instead of a broken TUI.

12 tests added.

## Fixes #159: stale `Cargo.lock` in tagged releases

`git show 1.2.0:Cargo.lock` still pins `jolt-tui 1.2.0-beta.2`. `versions.sh` rewrites `Cargo.toml` but never re-resolves the lock, and the release workflow only stages `Cargo.toml`.

- `versions.sh` re-resolves with `cargo update --workspace` after the version rewrite. Offline first, network fallback. It never fails the script, since two other jobs call it and only need the manifest rewritten.
- `release.yml` stages `Cargo.lock` alongside `Cargo.toml`.

Tested with cargo present, cargo absent, and a cargo that always fails.

## Also

`scripts/check --test` ran a package-scoped `cargo test` from `cli/`, silently skipping the `jolt-platform`, `jolt-protocol` and `jolt-theme` tests. CI already uses `--workspace`, so the script now matches.
